### PR TITLE
Update website docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ QUBOLib instances are distributed as a Julia artifact recorded in
 downloaded from the package releases the first time `QUBOLib.access` needs it,
 then copied into a local `qubolib` directory for use.
 
+The database-query examples below use SQLite.jl and DataFrames.jl directly, so
+add them to the active Julia project before running those examples:
+
+```julia
+julia> import Pkg; Pkg.add(["SQLite", "DataFrames"])
+```
+
 Use `QUBOLib.access` to open the local index, query the SQLite database for
 instance identifiers, and load the selected models from the HDF5 archive:
 
@@ -60,7 +67,7 @@ directory and call `QUBOLib.access()` again without `clear = true`.
 ## Accessing the instance index database
 
 > **Warning**
-> This requires [SQLite.jl](https://github.com/JuliaDatabases/SQLite.jl) and [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl) to be installed.
+> This requires [SQLite.jl](https://github.com/JuliaDatabases/SQLite.jl) and [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl) to be installed in the active Julia project.
 
 ```julia
 julia> using QUBOLib

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DocumenterDiagrams = "a106ebf2-4182-4cba-90d4-44cd3cc36e85"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 QUBOLib = "c2d3eca2-2309-4628-88a9-9d4a554e7c47"
 
 [compat]
 Documenter = "1"
-DocumenterDiagrams = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,4 @@
 using Documenter
-using DocumenterDiagrams
 using DocumenterInterLinks
 
 using QUBOLib

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,11 @@
 # QUBOLib.jl
 
-## Getting Started
+QUBOLib provides a Julia interface to a curated collection of binary quadratic
+optimization benchmark instances.
 
-### Installation
+## Installation
+
+Install the package directly from GitHub:
 
 ```julia
 import Pkg
@@ -11,3 +14,54 @@ Pkg.add(url="https://github.com/JuliaQUBO/QUBOLib.jl")
 
 using QUBOLib
 ```
+
+## Retrieving instances
+
+QUBOLib instances are distributed as a Julia artifact recorded in
+[`Artifacts.toml`](https://github.com/JuliaQUBO/QUBOLib.jl/blob/main/Artifacts.toml),
+not as checked-in data files. The artifact is downloaded from the package
+releases the first time [`QUBOLib.access`](@ref) needs it, then copied into a
+local `qubolib` directory for use.
+
+Use [`QUBOLib.access`](@ref) to open the local index, query the SQLite database
+for instance identifiers, and load the selected models from the HDF5 archive:
+
+```julia
+using QUBOLib
+using SQLite, DataFrames
+
+model = QUBOLib.access() do index
+    df = DBInterface.execute(
+        QUBOLib.database(index),
+        "SELECT instance FROM Instances ORDER BY instance LIMIT 1;"
+    ) |> DataFrame
+
+    return QUBOLib.load_instance(index, only(df[!, :instance]))
+end
+```
+
+By default, `QUBOLib.access()` creates or reuses `joinpath(pwd(), "qubolib")`.
+Pass `path = "/path/to/workdir"` to keep the local copy somewhere else. To
+refresh the local copy from the packaged artifact, delete the local `qubolib`
+directory and call [`QUBOLib.access`](@ref) again.
+
+## Accessing the instance index database
+
+The local index exposes both the SQLite database and the HDF5 archive:
+
+```julia
+using QUBOLib
+using SQLite, DataFrames
+
+models = QUBOLib.access() do index
+    df = DBInterface.execute(
+        QUBOLib.database(index),
+        "SELECT instance FROM Instances WHERE dimension BETWEEN 100 AND 200;"
+    ) |> DataFrame
+
+    return [QUBOLib.load_instance(index, i) for i in df[!, :instance]]
+end
+```
+
+See [Basic Usage](manual/1-basic.md) for the common access workflow and
+[API](@ref) for the exported functions.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,6 +26,15 @@ local `qubolib` directory for use.
 Use [`QUBOLib.access`](@ref) to open the local index, query the SQLite database
 for instance identifiers, and load the selected models from the HDF5 archive:
 
+The database-query examples below use SQLite.jl and DataFrames.jl directly, so
+add them to the active Julia project before running those examples:
+
+```julia
+import Pkg
+
+Pkg.add(["SQLite", "DataFrames"])
+```
+
 ```julia
 using QUBOLib
 using SQLite, DataFrames

--- a/docs/src/manual/1-basic.md
+++ b/docs/src/manual/1-basic.md
@@ -1,6 +1,9 @@
 # Basic Usage
 
-## Getting Started
+## Opening the library index
+
+Use [`QUBOLib.access`](@ref) to create or reuse a local copy of the packaged
+library artifact and open the instance index:
 
 ```julia
 using QUBOLib
@@ -9,3 +12,37 @@ QUBOLib.access() do index
     print(index)
 end
 ```
+
+By default, the local copy is stored in `joinpath(pwd(), "qubolib")`. Pass a
+custom `path` when the data should be kept outside the current working
+directory:
+
+```julia
+using QUBOLib
+
+QUBOLib.access(path = "/path/to/workdir") do index
+    print(index)
+end
+```
+
+## Loading an instance
+
+The [`QUBOLib.database`](@ref) function exposes the SQLite index, and
+[`QUBOLib.load_instance`](@ref) loads a selected model from the HDF5 archive:
+
+```julia
+using QUBOLib
+using SQLite, DataFrames
+
+model = QUBOLib.access() do index
+    df = DBInterface.execute(
+        QUBOLib.database(index),
+        "SELECT instance FROM Instances ORDER BY instance LIMIT 1;"
+    ) |> DataFrame
+
+    return QUBOLib.load_instance(index, only(df[!, :instance]))
+end
+```
+
+To refresh the local copy from the packaged artifact, delete the local
+`qubolib` directory and call [`QUBOLib.access`](@ref) again.

--- a/docs/src/manual/1-basic.md
+++ b/docs/src/manual/1-basic.md
@@ -30,6 +30,15 @@ end
 The [`QUBOLib.database`](@ref) function exposes the SQLite index, and
 [`QUBOLib.load_instance`](@ref) loads a selected model from the HDF5 archive:
 
+The example below queries the SQLite database directly, so add SQLite.jl and
+DataFrames.jl to the active Julia project before running it:
+
+```julia
+import Pkg
+
+Pkg.add(["SQLite", "DataFrames"])
+```
+
 ```julia
 using QUBOLib
 using SQLite, DataFrames

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -8,11 +8,13 @@ function test_docs()
         @test occursin("QUBOLib.access", docs_home)
         @test occursin("QUBOLib.load_instance", docs_home)
         @test occursin("delete the local `qubolib`", docs_home)
+        @test occursin("Pkg.add([\"SQLite\", \"DataFrames\"])", docs_home)
 
         @test occursin("Opening the library index", basic)
         @test occursin("Loading an instance", basic)
         @test occursin("QUBOLib.database", basic)
         @test occursin("QUBOLib.load_instance", basic)
+        @test occursin("Pkg.add([\"SQLite\", \"DataFrames\"])", basic)
     end
 
     return nothing

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1,0 +1,19 @@
+function test_docs()
+    @testset "-> Website docs" begin
+        docs_home = read(joinpath(QUBOLib.root_path(), "docs", "src", "index.md"), String)
+        basic = read(joinpath(QUBOLib.root_path(), "docs", "src", "manual", "1-basic.md"), String)
+
+        @test occursin("Retrieving instances", docs_home)
+        @test occursin("Julia artifact", docs_home)
+        @test occursin("QUBOLib.access", docs_home)
+        @test occursin("QUBOLib.load_instance", docs_home)
+        @test occursin("delete the local `qubolib`", docs_home)
+
+        @test occursin("Opening the library index", basic)
+        @test occursin("Loading an instance", basic)
+        @test occursin("QUBOLib.database", basic)
+        @test occursin("QUBOLib.load_instance", basic)
+    end
+
+    return nothing
+end

--- a/test/readme.jl
+++ b/test/readme.jl
@@ -7,6 +7,7 @@ function test_readme()
         @test occursin("QUBOLib.access", readme)
         @test occursin("QUBOLib.load_instance", readme)
         @test occursin("delete the local `qubolib`", readme)
+        @test occursin("Pkg.add([\"SQLite\", \"DataFrames\"])", readme)
         @test !occursin("`clear = true` to recreate it from the packaged artifact", readme)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("synthesis.jl")
 include("library/path.jl")
 include("library/access.jl")
 include("readme.jl")
+include("docs.jl")
 
 function main()
     @testset "♣ QUBOLib.jl «$(QUBOLib.__version__())» Test Suite ♣" verbose = true begin
@@ -15,6 +16,7 @@ function main()
         test_library_access()
         test_synthesis()
         test_readme()
+        test_docs()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Update the Documenter website home page with current artifact-backed instance access guidance.
- Expand the basic usage page with local library access, custom paths, and instance loading examples.
- Add a focused package test that checks the website docs include the expected access guidance.
- Remove the unused `DocumenterDiagrams` docs dependency so the active website build does not precompile Kroki.

## Tests run

- `julia --project -e 'using Test; import QUBOLib; include("test/docs.jl"); test_docs()'` - passed, 9/9 website docs assertions.
- `julia --project -e 'import Pkg; Pkg.test()'` - passed, 32/32 package tests.
- `git diff --check` - passed.
- `make docs` - completed as a no-op with `make: 'docs' is up to date.` because the `docs/` directory satisfies the target name locally.
- `julia --project=docs ./docs/make.jl --skip-deploy` - passed; emitted the existing missing-docstring warnings for `QUBOLib.build!`, `QUBOLib.run!`, `QUBOLib.cache_data_path`, and `QUBOLib.clear!`.

## Notes about tests not run

- Before removing the unused `DocumenterDiagrams` dependency, `julia --project=docs ./docs/make.jl --skip-deploy` stalled locally in `Kroki` precompilation before reaching the documentation sources. After the dependency cleanup, the standard docs build passed.

Closes #4