### PR TITLE
Add solution record incumbents

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,6 +38,9 @@ QUBOLib.access
 QUBOLib.load_collection
 QUBOLib.load_instance
 QUBOLib.load_solution
+QUBOLib.best_solution_record
+QUBOLib.load_best_solution
+QUBOLib.list_solution_records
 ```
 
 ## Data Management
@@ -46,6 +49,8 @@ QUBOLib.load_solution
 QUBOLib.add_collection!
 QUBOLib.add_instance!
 QUBOLib.add_solution!
+QUBOLib.add_submission!
+QUBOLib.add_solution_record!
 QUBOLib.add_solver!
 ```
 

--- a/src/assets/qubolib.sql
+++ b/src/assets/qubolib.sql
@@ -40,6 +40,8 @@ CREATE TABLE Instances
   collection        TEXT    NOT NULL   ,
   name              TEXT        NULL   ,
   dimension         INTEGER NOT NULL   ,
+  sense             TEXT    NOT NULL DEFAULT 'min',
+  domain            TEXT    NOT NULL DEFAULT 'bool',
   min               REAL    NOT NULL   ,
   max               REAL    NOT NULL   ,
   abs_min           REAL    NOT NULL   ,
@@ -71,3 +73,88 @@ CREATE TABLE Solvers
   version     TEXT        NULL,
   description TEXT        NULL
 );
+
+CREATE TABLE Submissions
+(
+  submission        INTEGER PRIMARY KEY,
+  submitter         TEXT        NULL,
+  date              TEXT        NULL,
+  reference         TEXT        NULL,
+  modeling_approach TEXT        NULL,
+  workflow          TEXT        NULL,
+  algorithm_type    TEXT        NULL,
+  runs              INTEGER     NULL,
+  feasible_runs     INTEGER     NULL,
+  successful_runs   INTEGER     NULL,
+  success_threshold REAL        NULL,
+  hardware          TEXT        NULL,
+  total_runtime     REAL        NULL,
+  cpu_runtime       REAL        NULL,
+  gpu_runtime       REAL        NULL,
+  qpu_runtime       REAL        NULL,
+  other_runtime     REAL        NULL,
+  remarks           TEXT        NULL,
+  source_path       TEXT        NULL,
+  metadata          TEXT        NULL
+);
+
+CREATE TABLE SolutionRecords
+(
+  record              INTEGER PRIMARY KEY,
+  instance            INTEGER NOT NULL,
+  submission          INTEGER     NULL,
+  solution            INTEGER     NULL,
+  bitstring           TEXT        NULL,
+  qubo_value          REAL        NULL,
+  source_value        REAL        NULL,
+  objective_bound     REAL        NULL,
+  proven_optimal      BOOLEAN NOT NULL DEFAULT FALSE,
+  feasibility_status  TEXT        NULL,
+  validation_status   TEXT        NULL,
+  incumbent_candidate BOOLEAN NOT NULL DEFAULT TRUE,
+  source_path         TEXT        NULL,
+  metadata            TEXT        NULL,
+  FOREIGN KEY (instance)   REFERENCES Instances   (instance)   ON DELETE CASCADE,
+  FOREIGN KEY (submission) REFERENCES Submissions (submission) ON DELETE SET NULL,
+  FOREIGN KEY (solution)   REFERENCES Solutions   (solution)   ON DELETE SET NULL
+);
+
+CREATE VIEW BestSolutions AS
+SELECT *
+FROM (
+  SELECT
+    r.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY r.instance
+      ORDER BY
+        CASE
+          WHEN lower(i.sense) = 'max' THEN -r.qubo_value
+          ELSE r.qubo_value
+        END ASC,
+        r.proven_optimal DESC,
+        CASE lower(r.validation_status)
+          WHEN 'verified' THEN 3
+          WHEN 'validated' THEN 2
+          WHEN 'evaluated' THEN 1
+          ELSE 0
+        END DESC,
+        CASE WHEN s.date IS NULL THEN 1 ELSE 0 END ASC,
+        s.date ASC,
+        r.record ASC
+    ) AS incumbent_rank
+  FROM SolutionRecords AS r
+  JOIN Instances AS i
+    ON i.instance = r.instance
+  LEFT JOIN Submissions AS s
+    ON s.submission = r.submission
+  WHERE r.bitstring IS NOT NULL
+    AND length(r.bitstring) = i.dimension
+    AND r.bitstring NOT GLOB '*[^01]*'
+    AND r.qubo_value IS NOT NULL
+    AND r.qubo_value > -1.7976931348623157e308
+    AND r.qubo_value <  1.7976931348623157e308
+    AND lower(coalesce(r.validation_status, '')) IN ('evaluated', 'validated', 'verified')
+    AND r.incumbent_candidate = TRUE
+    AND lower(coalesce(r.feasibility_status, '')) NOT IN ('invalid', 'infeasible', 'withdrawn', 'unmapped')
+)
+WHERE incumbent_rank = 1;

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -125,6 +125,43 @@ The `solution` argument is a [`QUBOTools.SampleSet`](@extref), which is a collec
 function add_solution! end
 
 @doc raw"""
+    add_submission!(index::LibraryIndex; kwargs...)
+    add_submission!(index::LibraryIndex, data::Dict{String,Any})
+
+Registers benchmark-run provenance shared by one or more solution records.
+"""
+function add_submission! end
+
+@doc raw"""
+    add_solution_record!(index::LibraryIndex, instance::Integer; kwargs...)
+
+Registers a submitted or reference bitstring and its provenance for an instance.
+Records are preserved even when they are not incumbent candidates.
+"""
+function add_solution_record! end
+
+@doc raw"""
+    best_solution_record(index::LibraryIndex, instance::Integer)
+
+Returns the selected incumbent solution record for an instance, or `nothing`.
+"""
+function best_solution_record end
+
+@doc raw"""
+    load_best_solution(index::LibraryIndex, instance::Integer)
+
+Loads the HDF5 sample set associated with the selected incumbent, or `nothing`.
+"""
+function load_best_solution end
+
+@doc raw"""
+    list_solution_records(index::LibraryIndex, instance::Integer)
+
+Returns all solution records for an instance, including non-incumbents.
+"""
+function list_solution_records end
+
+@doc raw"""
     remove_solution!(index::LibraryIndex, instance::Integer, solution::Integer)
 
 Removes a solution from the library index.

--- a/src/library/access.jl
+++ b/src/library/access.jl
@@ -93,7 +93,11 @@ function load_database(path::AbstractString)::Union{SQLite.DB,Nothing}
     if !isfile(path)
         return nothing
     else
-        return SQLite.DB(path)
+        db = SQLite.DB(path)
+
+        migrate_database!(db)
+
+        return db
     end
 end
 
@@ -112,7 +116,144 @@ function create_database(path::AbstractString)
         end
     end
 
+    migrate_database!(db)
+
     return db
+end
+
+function _table_exists(db::SQLite.DB, table::AbstractString)::Bool
+    df = DBInterface.execute(
+        db,
+        """
+        SELECT COUNT(*) AS n
+        FROM sqlite_master
+        WHERE type IN ('table', 'view') AND name = ?;
+        """,
+        (String(table),),
+    ) |> DataFrame
+
+    return only(df[!, :n]) > 0
+end
+
+function _column_exists(db::SQLite.DB, table::AbstractString, column::AbstractString)::Bool
+    df = DBInterface.execute(db, "PRAGMA table_info($(String(table)));") |> DataFrame
+
+    return String(column) in string.(df[!, :name])
+end
+
+function migrate_database!(db::SQLite.DB)
+    DBInterface.execute(db, "PRAGMA foreign_keys = ON;")
+
+    if _table_exists(db, "Instances") && !_column_exists(db, "Instances", "sense")
+        DBInterface.execute(db, "ALTER TABLE Instances ADD COLUMN sense TEXT NOT NULL DEFAULT 'min';")
+    end
+
+    if _table_exists(db, "Instances") && !_column_exists(db, "Instances", "domain")
+        DBInterface.execute(db, "ALTER TABLE Instances ADD COLUMN domain TEXT NOT NULL DEFAULT 'bool';")
+    end
+
+    DBInterface.execute(
+        db,
+        """
+        CREATE TABLE IF NOT EXISTS Submissions
+        (
+          submission        INTEGER PRIMARY KEY,
+          submitter         TEXT        NULL,
+          date              TEXT        NULL,
+          reference         TEXT        NULL,
+          modeling_approach TEXT        NULL,
+          workflow          TEXT        NULL,
+          algorithm_type    TEXT        NULL,
+          runs              INTEGER     NULL,
+          feasible_runs     INTEGER     NULL,
+          successful_runs   INTEGER     NULL,
+          success_threshold REAL        NULL,
+          hardware          TEXT        NULL,
+          total_runtime     REAL        NULL,
+          cpu_runtime       REAL        NULL,
+          gpu_runtime       REAL        NULL,
+          qpu_runtime       REAL        NULL,
+          other_runtime     REAL        NULL,
+          remarks           TEXT        NULL,
+          source_path       TEXT        NULL,
+          metadata          TEXT        NULL
+        );
+        """,
+    )
+
+    DBInterface.execute(
+        db,
+        """
+        CREATE TABLE IF NOT EXISTS SolutionRecords
+        (
+          record              INTEGER PRIMARY KEY,
+          instance            INTEGER NOT NULL,
+          submission          INTEGER     NULL,
+          solution            INTEGER     NULL,
+          bitstring           TEXT        NULL,
+          qubo_value          REAL        NULL,
+          source_value        REAL        NULL,
+          objective_bound     REAL        NULL,
+          proven_optimal      BOOLEAN NOT NULL DEFAULT FALSE,
+          feasibility_status  TEXT        NULL,
+          validation_status   TEXT        NULL,
+          incumbent_candidate BOOLEAN NOT NULL DEFAULT TRUE,
+          source_path         TEXT        NULL,
+          metadata            TEXT        NULL,
+          FOREIGN KEY (instance)   REFERENCES Instances   (instance)   ON DELETE CASCADE,
+          FOREIGN KEY (submission) REFERENCES Submissions (submission) ON DELETE SET NULL,
+          FOREIGN KEY (solution)   REFERENCES Solutions   (solution)   ON DELETE SET NULL
+        );
+        """,
+    )
+
+    DBInterface.execute(db, "DROP VIEW IF EXISTS BestSolutions;")
+    DBInterface.execute(
+        db,
+        """
+        CREATE VIEW BestSolutions AS
+        SELECT *
+        FROM (
+          SELECT
+            r.*,
+            ROW_NUMBER() OVER (
+              PARTITION BY r.instance
+              ORDER BY
+                CASE
+                  WHEN lower(i.sense) = 'max' THEN -r.qubo_value
+                  ELSE r.qubo_value
+                END ASC,
+                r.proven_optimal DESC,
+                CASE lower(r.validation_status)
+                  WHEN 'verified' THEN 3
+                  WHEN 'validated' THEN 2
+                  WHEN 'evaluated' THEN 1
+                  ELSE 0
+                END DESC,
+                CASE WHEN s.date IS NULL THEN 1 ELSE 0 END ASC,
+                s.date ASC,
+                r.record ASC
+            ) AS incumbent_rank
+          FROM SolutionRecords AS r
+          JOIN Instances AS i
+            ON i.instance = r.instance
+          LEFT JOIN Submissions AS s
+            ON s.submission = r.submission
+          WHERE r.bitstring IS NOT NULL
+            AND length(r.bitstring) = i.dimension
+            AND r.bitstring NOT GLOB '*[^01]*'
+            AND r.qubo_value IS NOT NULL
+            AND r.qubo_value > -1.7976931348623157e308
+            AND r.qubo_value <  1.7976931348623157e308
+            AND lower(coalesce(r.validation_status, '')) IN ('evaluated', 'validated', 'verified')
+            AND r.incumbent_candidate = TRUE
+            AND lower(coalesce(r.feasibility_status, '')) NOT IN ('invalid', 'infeasible', 'withdrawn', 'unmapped')
+        )
+        WHERE incumbent_rank = 1;
+        """,
+    )
+
+    return nothing
 end
 
 function load_archive(

--- a/src/library/instances.jl
+++ b/src/library/instances.jl
@@ -21,6 +21,8 @@ function add_instance!(
                 collection       ,
                 name             ,
                 dimension        ,
+                sense            ,
+                domain           ,
                 min              ,
                 max              ,
                 abs_min          ,
@@ -34,12 +36,14 @@ function add_instance!(
                 quadratic_density
             ) 
         VALUES
-            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """,
         (
             String(collection),
             isnothing(name) ? missing : String(name),
             QUBOTools.dimension(model),
+            String(QUBOTools.sense(model)),
+            String(QUBOTools.domain(model)),
             min(minimum(L), minimum(Q)),
             max(maximum(L), maximum(Q)),
             min(minimum(abs, L), minimum(abs, Q)),

--- a/src/library/solutions.jl
+++ b/src/library/solutions.jl
@@ -5,14 +5,356 @@ function _write_solution(
 ) where {P<:Union{HDF5.File,HDF5.Group}}
     HDF5.create_group(fp, "solution")
 
-    QUBOTools._write_solution_data(fp, sol, fmt)
+    _write_solution_data(fp, sol, fmt)
 
     fp["solution"]["sense"]  = String(QUBOTools.sense(sol))
     fp["solution"]["domain"] = String(QUBOTools.domain(sol))
 
-    QUBOTools._write_solution_metadata(fp, sol, fmt)
+    _write_solution_metadata(fp, sol, fmt)
 
     return nothing
+end
+
+function _write_solution_data(
+    fp::P,
+    sol::QUBOTools.AbstractSolution{T,U},
+    fmt::QUBOTools.AbstractFormat,
+) where {P<:Union{HDF5.File,HDF5.Group},T,U}
+    HDF5.create_group(fp["solution"], "data")
+
+    if isempty(sol)
+        states = zeros(U, 0, 0)
+        values = zeros(T, 0)
+        reads = zeros(Int, 0)
+    else
+        samples = collect(sol)
+        states = Matrix{U}(undef, length(samples), length(QUBOTools.state(first(samples))))
+        values = Vector{T}(undef, length(samples))
+        reads = Vector{Int}(undef, length(samples))
+
+        for (i, sample) in enumerate(samples)
+            states[i, :] = QUBOTools.state(sample)
+            values[i] = QUBOTools.value(sample)
+            reads[i] = QUBOTools.reads(sample)
+        end
+    end
+
+    write(HDF5.create_dataset(fp["solution"]["data"], "state", U, size(states)), states)
+    write(HDF5.create_dataset(fp["solution"]["data"], "value", T, size(values)), values)
+    write(HDF5.create_dataset(fp["solution"]["data"], "reads", Int, size(reads)), reads)
+
+    return nothing
+end
+
+function _write_solution_metadata(
+    fp::P,
+    sol::QUBOTools.AbstractSolution,
+    fmt::QUBOTools.AbstractFormat,
+) where {P<:Union{HDF5.File,HDF5.Group}}
+    fp["solution"]["metadata"] = JSON.json(QUBOTools.metadata(sol))
+
+    return nothing
+end
+
+function _data_dict(data)
+    return Dict{String,Any}(String(k) => v for (k, v) in pairs(data))
+end
+
+function _sql_value(value)
+    return isnothing(value) ? missing : value
+end
+
+function _sql_value(value::AbstractString)
+    return String(value)
+end
+
+function _sql_value(value::Symbol)
+    return String(value)
+end
+
+function _metadata_value(metadata)
+    if isnothing(metadata) || ismissing(metadata)
+        return missing
+    elseif metadata isa AbstractString
+        return String(metadata)
+    else
+        return JSON.json(metadata)
+    end
+end
+
+function _submission_value(data::AbstractDict, key::AbstractString)
+    return _sql_value(get(data, key, missing))
+end
+
+function _normalize_bitstring(bitstring)
+    if isnothing(bitstring) || ismissing(bitstring)
+        return missing
+    elseif bitstring isa AbstractString
+        value = String(bitstring)
+
+        if occursin(r"[^01]", value)
+            error("Bitstrings must be ASCII strings containing only '0' and '1'")
+        end
+
+        return value
+    elseif bitstring isa AbstractVector{<:Integer}
+        return sprint() do io
+            for bit in bitstring
+                if bit == -1 || bit == 0
+                    print(io, '0')
+                elseif bit == 1
+                    print(io, '1')
+                else
+                    error("Bitstring vectors must contain only 0/1 or -1/1 values")
+                end
+            end
+        end
+    else
+        error("Bitstrings must be strings or integer vectors")
+    end
+end
+
+function _bitstring_state(bitstring::AbstractString)
+    return [bit == '1' ? 1 : 0 for bit in bitstring]
+end
+
+function _solution_bitstring(sol::QUBOTools.AbstractSolution)
+    if isempty(sol)
+        return missing
+    else
+        return _normalize_bitstring(QUBOTools.state(first(sol)))
+    end
+end
+
+function _instance_dimension(index::LibraryIndex, instance::Integer)
+    db = QUBOLib.database(index)
+    df = DBInterface.execute(
+        db,
+        "SELECT dimension FROM Instances WHERE instance = ?;",
+        (instance,),
+    ) |> DataFrame
+
+    if size(df, 1) == 0
+        error("Instance '$instance' does not exist")
+    end
+
+    return only(df[!, :dimension])::Integer
+end
+
+function _evaluate_qubo_value(index::LibraryIndex, instance::Integer, bitstring::AbstractString)
+    model = load_instance(index, instance)
+    form = QUBOTools.form(model, :sparse; domain = :bool)
+
+    return QUBOTools.value(_bitstring_state(bitstring), form)
+end
+
+function add_submission!(index::LibraryIndex; kwargs...)::Integer
+    return add_submission!(index, _data_dict(kwargs))
+end
+
+function add_submission!(index::LibraryIndex, data::AbstractDict)::Integer
+    @assert isopen(index)
+
+    data = _data_dict(data)
+    db = QUBOLib.database(index)
+
+    query = DBInterface.execute(
+        db,
+        """
+        INSERT INTO Submissions
+            (
+                submitter,
+                date,
+                reference,
+                modeling_approach,
+                workflow,
+                algorithm_type,
+                runs,
+                feasible_runs,
+                successful_runs,
+                success_threshold,
+                hardware,
+                total_runtime,
+                cpu_runtime,
+                gpu_runtime,
+                qpu_runtime,
+                other_runtime,
+                remarks,
+                source_path,
+                metadata
+            )
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            _submission_value(data, "submitter"),
+            _submission_value(data, "date"),
+            _submission_value(data, "reference"),
+            _submission_value(data, "modeling_approach"),
+            _submission_value(data, "workflow"),
+            _submission_value(data, "algorithm_type"),
+            _submission_value(data, "runs"),
+            _submission_value(data, "feasible_runs"),
+            _submission_value(data, "successful_runs"),
+            _submission_value(data, "success_threshold"),
+            _submission_value(data, "hardware"),
+            _submission_value(data, "total_runtime"),
+            _submission_value(data, "cpu_runtime"),
+            _submission_value(data, "gpu_runtime"),
+            _submission_value(data, "qpu_runtime"),
+            _submission_value(data, "other_runtime"),
+            _submission_value(data, "remarks"),
+            _submission_value(data, "source_path"),
+            _metadata_value(get(data, "metadata", missing)),
+        ),
+    )
+
+    return DBInterface.lastrowid(query)::Integer
+end
+
+function add_solution_record!(
+    index::LibraryIndex,
+    instance::Integer;
+    submission = nothing,
+    solution = nothing,
+    bitstring = nothing,
+    qubo_value = nothing,
+    source_value = nothing,
+    objective_bound = nothing,
+    proven_optimal::Bool = false,
+    feasibility_status = "unknown",
+    validation_status = nothing,
+    incumbent_candidate::Bool = true,
+    source_path = nothing,
+    metadata = nothing,
+)::Integer
+    @assert isopen(index)
+
+    bitstring = _normalize_bitstring(bitstring)
+    value = _sql_value(qubo_value)
+    status = validation_status
+    dimension = _instance_dimension(index, instance)
+
+    if ismissing(value) && !ismissing(bitstring) && length(bitstring) == dimension
+        value = _evaluate_qubo_value(index, instance, bitstring)
+
+        if isnothing(status)
+            status = "evaluated"
+        end
+    elseif isnothing(status)
+        status = ismissing(value) ? "unevaluated" : "evaluated"
+    end
+
+    db = QUBOLib.database(index)
+
+    query = DBInterface.execute(
+        db,
+        """
+        INSERT INTO SolutionRecords
+            (
+                instance,
+                submission,
+                solution,
+                bitstring,
+                qubo_value,
+                source_value,
+                objective_bound,
+                proven_optimal,
+                feasibility_status,
+                validation_status,
+                incumbent_candidate,
+                source_path,
+                metadata
+            )
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            instance,
+            _sql_value(submission),
+            _sql_value(solution),
+            bitstring,
+            value,
+            _sql_value(source_value),
+            _sql_value(objective_bound),
+            proven_optimal,
+            _sql_value(feasibility_status),
+            _sql_value(status),
+            incumbent_candidate,
+            _sql_value(source_path),
+            _metadata_value(metadata),
+        ),
+    )
+
+    return DBInterface.lastrowid(query)::Integer
+end
+
+function list_solution_records(index::LibraryIndex, instance::Integer)::DataFrame
+    @assert isopen(index)
+
+    db = QUBOLib.database(index)
+
+    return DBInterface.execute(
+        db,
+        "SELECT * FROM SolutionRecords WHERE instance = ? ORDER BY record;",
+        (instance,),
+    ) |> DataFrame
+end
+
+function best_solution_record(index::LibraryIndex, instance::Integer)
+    @assert isopen(index)
+
+    db = QUBOLib.database(index)
+    df = DBInterface.execute(
+        db,
+        "SELECT * FROM BestSolutions WHERE instance = ? LIMIT 1;",
+        (instance,),
+    ) |> DataFrame
+
+    if size(df, 1) == 0
+        return nothing
+    else
+        return df[1, :]
+    end
+end
+
+function load_solution(index::LibraryIndex, solution::Integer)
+    @assert isopen(index)
+
+    h5 = QUBOLib.archive(index)
+
+    return QUBOTools.read_solution(h5["solutions"][string(solution)], _qubin_format())
+end
+
+function load_solution(index::LibraryIndex, instance::Integer, solution::Integer)
+    @assert isopen(index)
+
+    db = QUBOLib.database(index)
+    df = DBInterface.execute(
+        db,
+        """
+        SELECT COUNT(*) AS n
+        FROM Solutions
+        WHERE instance = ? AND solution = ?;
+        """,
+        (instance, solution),
+    ) |> DataFrame
+
+    if only(df[!, :n]) == 0
+        error("Solution '$solution' does not belong to instance '$instance'")
+    end
+
+    return load_solution(index, solution)
+end
+
+function load_best_solution(index::LibraryIndex, instance::Integer)
+    record = best_solution_record(index, instance)
+
+    if isnothing(record) || ismissing(record[:solution])
+        return nothing
+    else
+        return load_solution(index, Int(record[:solution]))
+    end
 end
 
 function add_solution!(index::LibraryIndex, instance::Integer, sol::QUBOTools.SampleSet{Float64,Int})::Integer
@@ -45,6 +387,18 @@ function add_solution!(index::LibraryIndex, instance::Integer, sol::QUBOTools.Sa
     group = HDF5.create_group(h5["solutions"], string(i))
 
     _write_solution(group, sol, _qubin_format())
+
+    add_solution_record!(
+        index,
+        instance;
+        solution = i,
+        bitstring = _solution_bitstring(sol),
+        source_value = value,
+        proven_optimal = optimal,
+        feasibility_status = "feasible",
+        incumbent_candidate = true,
+        metadata = data,
+    )
 
     return i
 end

--- a/test/library/access.jl
+++ b/test/library/access.jl
@@ -15,5 +15,111 @@ function test_library_access()
         end
     end
 
+    @testset "Solution records" begin
+        mktempdir() do path
+            model = QUBOTools.Model(
+                Dict(1 => 1.0, 2 => 2.0, 3 => 4.0),
+                Dict{Tuple{Int,Int},Float64}((1, 2) => 0.5),
+            )
+
+            QUBOLib.access(; path, clear = true) do index
+                instance = QUBOLib.add_instance!(index, model)
+
+                late_submission = QUBOLib.add_submission!(
+                    index;
+                    submitter = "late",
+                    date = "2026-01-02",
+                )
+                early_submission = QUBOLib.add_submission!(
+                    index;
+                    submitter = "early",
+                    date = "2026-01-01",
+                )
+
+                invalid = QUBOLib.add_solution_record!(
+                    index,
+                    instance;
+                    submission = early_submission,
+                    bitstring = "000",
+                    validation_status = "invalid",
+                )
+                infeasible = QUBOLib.add_solution_record!(
+                    index,
+                    instance;
+                    submission = early_submission,
+                    bitstring = "000",
+                    feasibility_status = "infeasible",
+                )
+                worse = QUBOLib.add_solution_record!(
+                    index,
+                    instance;
+                    submission = early_submission,
+                    bitstring = "100",
+                )
+                late = QUBOLib.add_solution_record!(
+                    index,
+                    instance;
+                    submission = late_submission,
+                    bitstring = "000",
+                )
+                early = QUBOLib.add_solution_record!(
+                    index,
+                    instance;
+                    submission = early_submission,
+                    bitstring = "000",
+                )
+
+                records = QUBOLib.list_solution_records(index, instance)
+
+                @test size(records, 1) == 5
+                @test Set(records[!, :record]) == Set([invalid, infeasible, worse, late, early])
+
+                best = QUBOLib.best_solution_record(index, instance)
+
+                @test best[:record] == early
+                @test best[:qubo_value] ≈ 0.0
+                @test QUBOLib.load_best_solution(index, instance) === nothing
+
+                sol = QUBOTools.SampleSet{Float64,Int}(
+                    model,
+                    [[0, 0, 0]];
+                    metadata = Dict{String,Any}("status" => "optimal"),
+                )
+                solution = QUBOLib.add_solution!(index, instance, sol)
+                loaded = QUBOLib.load_solution(index, instance, solution)
+
+                @test !isempty(loaded)
+                @test QUBOTools.state(loaded[1]) == [0, 0, 0]
+
+                best = QUBOLib.best_solution_record(index, instance)
+                loaded_best = QUBOLib.load_best_solution(index, instance)
+
+                @test best[:solution] == solution
+                @test QUBOTools.state(loaded_best[1]) == [0, 0, 0]
+                @test QUBOTools.value(loaded_best, 1) ≈ QUBOTools.value(sol, 1)
+            end
+        end
+    end
+
+    @testset "Best solution sense" begin
+        mktempdir() do path
+            model = QUBOTools.Model(
+                Dict(1 => 1.0, 2 => 2.0),
+                Dict{Tuple{Int,Int},Float64}((1, 2) => 0.5);
+                sense = :max,
+            )
+
+            QUBOLib.access(; path, clear = true) do index
+                instance = QUBOLib.add_instance!(index, model)
+                low = QUBOLib.add_solution_record!(index, instance; bitstring = "00")
+                high = QUBOLib.add_solution_record!(index, instance; bitstring = "10")
+                best = QUBOLib.best_solution_record(index, instance)
+
+                @test best[:record] == high
+                @test best[:record] != low
+            end
+        end
+    end
+
     return nothing
 end

--- a/test/library/access.jl
+++ b/test/library/access.jl
@@ -121,5 +121,120 @@ function test_library_access()
         end
     end
 
+    @testset "Legacy index migration" begin
+        mktempdir() do path
+            _create_legacy_index(path)
+
+            model = QUBOTools.Model(
+                Dict(1 => 1.0, 2 => 2.0),
+                Dict{Tuple{Int,Int},Float64}((1, 2) => 0.5),
+            )
+
+            QUBOLib.access(; path) do index
+                instance = QUBOLib.add_instance!(index, model)
+                record = QUBOLib.add_solution_record!(index, instance; bitstring = "00")
+                records = QUBOLib.list_solution_records(index, instance)
+                best = QUBOLib.best_solution_record(index, instance)
+
+                @test size(records, 1) == 1
+                @test only(records[!, :record]) == record
+                @test best[:record] == record
+            end
+        end
+    end
+
     return nothing
+end
+
+function _create_legacy_index(path::AbstractString)
+    lib_path = QUBOLib.library_path(path)
+
+    mkpath(lib_path)
+
+    db = QUBOLib.SQLite.DB(QUBOLib.database_path(lib_path))
+
+    try
+        for stmt in QUBOLib.each_stmt(_legacy_schema())
+            QUBOLib.DBInterface.execute(db, stmt)
+        end
+    finally
+        close(db)
+    end
+
+    h5 = QUBOLib.HDF5.h5open(QUBOLib.archive_path(lib_path), "w")
+
+    try
+        QUBOLib.HDF5.create_group(h5, "instances")
+        QUBOLib.HDF5.create_group(h5, "solutions")
+    finally
+        close(h5)
+    end
+
+    return nothing
+end
+
+function _legacy_schema()
+    return """
+    PRAGMA foreign_keys = ON;
+
+    CREATE TABLE Collections
+    (
+      collection  TEXT    PRIMARY KEY,
+      name        TEXT    NOT NULL   ,
+      author      TEXT        NULL   ,
+      year        INTEGER     NULL   ,
+      description TEXT        NULL   ,
+      url         TEXT        NULL
+    );
+
+    INSERT INTO Collections
+      (collection, name, author, year, description, url)
+    VALUES
+      (
+        'standalone',
+        'Standalone',
+        NULL,
+        NULL,
+        'Standalone instances',
+        NULL
+      );
+
+    CREATE TABLE Instances
+    (
+      instance          INTEGER PRIMARY KEY,
+      collection        TEXT    NOT NULL   ,
+      name              TEXT        NULL   ,
+      dimension         INTEGER NOT NULL   ,
+      min               REAL    NOT NULL   ,
+      max               REAL    NOT NULL   ,
+      abs_min           REAL    NOT NULL   ,
+      abs_max           REAL    NOT NULL   ,
+      linear_min        REAL    NOT NULL   ,
+      linear_max        REAL    NOT NULL   ,
+      quadratic_min     REAL    NOT NULL   ,
+      quadratic_max     REAL    NOT NULL   ,
+      density           REAL    NOT NULL   ,
+      linear_density    REAL    NOT NULL   ,
+      quadratic_density REAL    NOT NULL   ,
+      FOREIGN KEY (collection) REFERENCES Collections (collection) ON DELETE CASCADE
+    );
+
+    CREATE TABLE Solutions
+    (
+      solution INTEGER PRIMARY KEY,
+      instance INTEGER NOT NULL   ,
+      solver   TEXT        NULL   ,
+      value    REAL    NOT NULL   ,
+      optimal  BOOLEAN NOT NULL   ,
+      FOREIGN KEY (instance) REFERENCES Instances (instance) ON DELETE CASCADE,
+      FOREIGN KEY (solver)   REFERENCES Solvers (solver)
+    );
+
+    CREATE TABLE Solvers
+    (
+      solver      TEXT PRIMARY KEY,
+      version     TEXT        NULL,
+      description TEXT        NULL
+    );
+    """
 end


### PR DESCRIPTION
## Summary

- Adds `Submissions`, `SolutionRecords`, and `BestSolutions` to the SQLite schema.
- Adds incumbent APIs for adding submissions/records, listing records, selecting the best record, and loading the selected HDF5 sample set.
- Persists instance objective sense/domain for SQL incumbent ranking and keeps `add_solution!` backward compatible while linking added HDF5 solutions to solution records.
- Adds regression coverage for invalid/infeasible record exclusion, date and optimality tie breaks, HDF5 solution loading, and max-sense incumbent ranking.

## Tests run

- `julia --project -e 'using Test; import QUBOTools; import QUBOLib; include("test/library/access.jl"); test_library_access()'` - passed: 4 library access tests, 10 solution record tests, 2 max-sense tests.
- `julia --project -e 'import Pkg; Pkg.test()'` - passed: 56 tests.
- `julia --project=docs ./docs/make.jl --skip-deploy` - passed; emitted existing warnings about unrelated docstrings not included in the manual.
- `git diff --check` - passed.

## Notes

- `make docs` did not execute Documenter because the `docs/` directory shadows the Makefile target; the underlying Documenter command above was run directly.
- `julia --project=scripts/build --load scripts/build/runtests.jl --eval 'test_main()'` could not run locally because the `scripts/build` project does not have QUBOLib developed/instantiated in that environment.

Closes #15
