### PR TITLE
Import QOBLIB incumbent bitstrings

### DIFF
--- a/scripts/build/runtests.jl
+++ b/scripts/build/runtests.jl
@@ -70,24 +70,68 @@ function test_qoblib_qs_parser()
     return nothing
 end
 
-function _write_qoblib_fixture_group(root::AbstractString, group, filename::AbstractString)
+function _write_qoblib_fixture_group(root::AbstractString, group, filenames)
     group_path = mkpath(joinpath(root, group.path))
-    model_path = if group.nested
-        mkpath(joinpath(group_path, "fixture"))
-        joinpath(group_path, "fixture", filename)
-    else
-        joinpath(group_path, filename)
-    end
 
     write(joinpath(group_path, "README.md"), "# Fixture\n")
     write(
         joinpath(group_path, "metrics.csv"),
+        join(
+            vcat(
+                ["file,num_variables,density,min_coeff,max_coeff"],
+                ["$(basename(filename)),3,$(4 / 6),-4.0,3.0" for filename in filenames],
+            ),
+            "\n",
+        ) * "\n",
+    )
+
+    for filename in filenames
+        model_path = joinpath(group_path, filename)
+
+        mkpath(dirname(model_path))
+        write(model_path, _qoblib_fixture())
+    end
+
+    return nothing
+end
+
+function _write_qoblib_solution_dir(
+    root::AbstractString,
+    group,
+    readme::AbstractString = "# Fixture\n",
+)
+    solution_path = mkpath(joinpath(root, group.solution_path))
+
+    write(joinpath(solution_path, "README.md"), readme)
+
+    return solution_path
+end
+
+function _write_qoblib_portfolio_solution(root::AbstractString, group)
+    solution_path = _write_qoblib_solution_dir(
+        root,
+        group,
         """
-        file,num_variables,density,min_coeff,max_coeff
-        $(filename),3,$(4 / 6),-4.0,3.0
+        |   a |   t | s    |   b |   l | Best |
+        |-----|-----|------|-----|-----|------|
+        |  10 |  10 | orig |   4 |   0 |  999 |
         """,
     )
-    write(model_path, _qoblib_fixture())
+    archive_path = joinpath(solution_path, "a010_t10_orig_b004.tar.gz")
+
+    mktempdir() do path
+        member_dir = mkpath(joinpath(path, "a010_t10_orig_b004"))
+
+        write(
+            joinpath(member_dir, "a010_t10_orig_b004_l0.0.sol"),
+            """
+            x#1 0
+            x#2 1
+            x#3 0
+            """,
+        )
+        run(Cmd(["tar", "-czf", archive_path, "-C", path, "a010_t10_orig_b004"]))
+    end
 
     return nothing
 end
@@ -96,36 +140,48 @@ function test_qoblib_build_fixture()
     @testset "▶ QOBLIB build fixture" begin
         groups = (
             (
-                code           = "marketsplit",
-                problem_class  = "Market Split",
-                formulation    = "binary_unconstrained",
-                path           = "01-marketsplit/models/binary_unconstrained/qs_files",
-                expected_count = 1,
-                nested         = false,
+                code = "marketsplit",
+                problem_class = "Market Split",
+                formulation = "binary_unconstrained",
+                path = "01-marketsplit/models/binary_unconstrained/qs_files",
+                solution_path = "01-marketsplit/solutions",
+                solution_format = :bit_tokens,
+                expected_count = 2,
+                expected_incumbents = 1,
+                nested = false,
             ),
             (
-                code           = "labs",
-                problem_class  = "LABS",
-                formulation    = "quadratic_unconstrained",
-                path           = "02-labs/models/quadratic_unconstrained/qs_files",
+                code = "labs",
+                problem_class = "LABS",
+                formulation = "quadratic_unconstrained",
+                path = "02-labs/models/quadratic_unconstrained/qs_files",
+                solution_path = "02-labs/solutions",
+                solution_format = :labs_bits,
                 expected_count = 1,
-                nested         = false,
+                expected_incumbents = 1,
+                nested = false,
             ),
             (
-                code           = "portfolio",
-                problem_class  = "Portfolio Optimization",
-                formulation    = "unconstrained_quadratic_optimization",
-                path           = "06-portfolio/models/unconstrained_quadratic_optimization/qs_files",
+                code = "portfolio",
+                problem_class = "Portfolio Optimization",
+                formulation = "unconstrained_quadratic_optimization",
+                path = "06-portfolio/models/unconstrained_quadratic_optimization/qs_files",
+                solution_path = "06-portfolio/solutions/uqo",
+                solution_format = :assignments,
                 expected_count = 1,
-                nested         = true,
+                expected_incumbents = 1,
+                nested = true,
             ),
             (
-                code           = "independentset",
-                problem_class  = "Maximum Independent Set",
-                formulation    = "binary_unconstrained",
-                path           = "07-independentset/models/binary_unconstrained/qs_files",
+                code = "independentset",
+                problem_class = "Maximum Independent Set",
+                formulation = "binary_unconstrained",
+                path = "07-independentset/models/binary_unconstrained/qs_files",
+                solution_path = "07-independentset/solutions",
+                solution_format = :active_indices,
                 expected_count = 1,
-                nested         = false,
+                expected_incumbents = 1,
+                nested = false,
             ),
         )
 
@@ -134,9 +190,31 @@ function test_qoblib_build_fixture()
             write(joinpath(root, "LICENSE"), "Apache-2.0\n")
             write(joinpath(root, "LICENSE.data"), "CC-BY-4.0\n")
 
-            for group in groups
-                _write_qoblib_fixture_group(root, group, "$(group.code).qs")
-            end
+            _write_qoblib_fixture_group(
+                root,
+                groups[1],
+                ["marketsplit.qs", "marketsplit-missing.qs"],
+            )
+            solution_path = _write_qoblib_solution_dir(root, groups[1])
+            write(joinpath(solution_path, "marketsplit.opt.sol"), "1 0 1\n")
+
+            _write_qoblib_fixture_group(root, groups[2], ["labs001.qs"])
+            solution_path = _write_qoblib_solution_dir(root, groups[2])
+            write(joinpath(solution_path, "labs001.bst.sol"), "# Energy: 26\n1\n0\n")
+
+            _write_qoblib_fixture_group(
+                root,
+                groups[3],
+                ["a010_t10_orig_b004/uqo_a010_t10_orig_b004_l0.qs"],
+            )
+            _write_qoblib_portfolio_solution(root, groups[3])
+
+            _write_qoblib_fixture_group(root, groups[4], ["independentset.qs"])
+            solution_path = _write_qoblib_solution_dir(root, groups[4])
+            write(
+                joinpath(solution_path, "independentset.opt.sol"),
+                "# Objective value = 2\n1\n3\n",
+            )
 
             mktempdir() do path
                 QUBOLib.access(; path, clear = true) do index
@@ -154,13 +232,86 @@ function test_qoblib_build_fixture()
                             """,
                             (QOBLIB_COLLECTION,),
                         ) |> QUBOLib.DataFrame
+                    records =
+                        QUBOLib.DBInterface.execute(
+                            QUBOLib.database(index),
+                            """
+                            SELECT i.instance, i.name, r.bitstring, r.qubo_value,
+                                   r.source_value, r.proven_optimal,
+                                   r.feasibility_status, r.validation_status,
+                                   r.incumbent_candidate, r.source_path, r.solution
+                            FROM SolutionRecords AS r
+                            JOIN Instances AS i
+                              ON i.instance = r.instance
+                            ORDER BY i.name;
+                            """,
+                        ) |> QUBOLib.DataFrame
+                    best =
+                        QUBOLib.DBInterface.execute(
+                            QUBOLib.database(index),
+                            """
+                            SELECT i.instance, i.name, b.bitstring, b.qubo_value,
+                                   b.source_value, b.solution
+                            FROM BestSolutions AS b
+                            JOIN Instances AS i
+                              ON i.instance = b.instance
+                            ORDER BY i.name;
+                            """,
+                        ) |> QUBOLib.DataFrame
 
-                    @test count == 4
+                    @test count == 5
                     @test Set(data[!, :source_name]) == Set(["QOBLIB"])
                     @test Set(data[!, :problem_class]) ==
                           Set(getfield.(groups, :problem_class))
                     @test Set(data[!, :formulation]) == Set(getfield.(groups, :formulation))
                     @test all(endswith(path, ".qs") for path in data[!, :source_path])
+                    @test size(records, 1) == 5
+                    @test size(best, 1) == 4
+
+                    missing = only(
+                        eachrow(
+                            filter(row -> row[:name] == "marketsplit-missing.qs", records),
+                        ),
+                    )
+
+                    @test ismissing(missing[:bitstring])
+                    @test missing[:feasibility_status] == "missing"
+                    @test missing[:validation_status] == "missing"
+                    @test !Bool(missing[:incumbent_candidate])
+                    @test QUBOLib.load_best_solution(index, missing[:instance]) === nothing
+
+                    labs = only(eachrow(filter(row -> row[:name] == "labs001.qs", records)))
+                    portfolio = only(
+                        eachrow(
+                            filter(
+                                row ->
+                                    row[:name] ==
+                                    "a010_t10_orig_b004/uqo_a010_t10_orig_b004_l0.qs",
+                                records,
+                            ),
+                        ),
+                    )
+                    independent = only(
+                        eachrow(filter(row -> row[:name] == "independentset.qs", records)),
+                    )
+
+                    @test labs[:source_value] == 26
+                    @test labs[:qubo_value] != labs[:source_value]
+                    @test !Bool(labs[:proven_optimal])
+                    @test portfolio[:source_value] == 999
+                    @test Bool(independent[:proven_optimal])
+
+                    for row in eachrow(best)
+                        model = QUBOLib.load_instance(index, row[:instance])
+                        state = QUBOLib._bitstring_state(row[:bitstring])
+                        loaded = QUBOLib.load_best_solution(index, row[:instance])
+
+                        @test QUBOTools.value(model, state) ≈ row[:qubo_value]
+                        @test !isnothing(loaded)
+                        @test QUBOLib._normalize_bitstring(QUBOTools.state(loaded[1])) ==
+                              row[:bitstring]
+                        @test QUBOTools.value(loaded, 1) ≈ row[:qubo_value]
+                    end
                 end
             end
         end

--- a/scripts/build/sources/qoblib.jl
+++ b/scripts/build/sources/qoblib.jl
@@ -767,7 +767,6 @@ function _add_qoblib_incumbent!(
         validation_status = "validated",
         incumbent_candidate = true,
         source_path = _qoblib_source_path(root_path, info),
-        metadata,
     )
 
     return :imported

--- a/scripts/build/sources/qoblib.jl
+++ b/scripts/build/sources/qoblib.jl
@@ -7,36 +7,48 @@ const QOBLIB_ARCHIVE_URL = "https://github.com/$(QOBLIB_REPOSITORY)/archive/$(QO
 
 const QOBLIB_GROUPS = (
     (
-        code           = "marketsplit",
-        problem_class  = "Market Split",
-        formulation    = "binary_unconstrained",
-        path           = "01-marketsplit/models/binary_unconstrained/qs_files",
-        expected_count = 156,
-        nested         = false,
+        code                = "marketsplit",
+        problem_class       = "Market Split",
+        formulation         = "binary_unconstrained",
+        path                = "01-marketsplit/models/binary_unconstrained/qs_files",
+        solution_path       = "01-marketsplit/solutions",
+        solution_format     = :bit_tokens,
+        expected_count      = 156,
+        expected_incumbents = 115,
+        nested              = false,
     ),
     (
-        code           = "labs",
-        problem_class  = "LABS",
-        formulation    = "quadratic_unconstrained",
-        path           = "02-labs/models/quadratic_unconstrained/qs_files",
-        expected_count = 99,
-        nested         = false,
+        code                = "labs",
+        problem_class       = "LABS",
+        formulation         = "quadratic_unconstrained",
+        path                = "02-labs/models/quadratic_unconstrained/qs_files",
+        solution_path       = "02-labs/solutions",
+        solution_format     = :labs_bits,
+        expected_count      = 99,
+        expected_incumbents = 99,
+        nested              = false,
     ),
     (
-        code           = "portfolio",
-        problem_class  = "Portfolio Optimization",
-        formulation    = "unconstrained_quadratic_optimization",
-        path           = "06-portfolio/models/unconstrained_quadratic_optimization/qs_files",
-        expected_count = 128,
-        nested         = true,
+        code                = "portfolio",
+        problem_class       = "Portfolio Optimization",
+        formulation         = "unconstrained_quadratic_optimization",
+        path                = "06-portfolio/models/unconstrained_quadratic_optimization/qs_files",
+        solution_path       = "06-portfolio/solutions/uqo",
+        solution_format     = :assignments,
+        expected_count      = 128,
+        expected_incumbents = 128,
+        nested              = true,
     ),
     (
-        code           = "independentset",
-        problem_class  = "Maximum Independent Set",
-        formulation    = "binary_unconstrained",
-        path           = "07-independentset/models/binary_unconstrained/qs_files",
-        expected_count = 50,
-        nested         = false,
+        code                = "independentset",
+        problem_class       = "Maximum Independent Set",
+        formulation         = "binary_unconstrained",
+        path                = "07-independentset/models/binary_unconstrained/qs_files",
+        solution_path       = "07-independentset/solutions",
+        solution_format     = :active_indices,
+        expected_count      = 50,
+        expected_incumbents = 50,
+        nested              = false,
     ),
 )
 
@@ -258,6 +270,536 @@ function QUBOTools.read_model(path::AbstractString, fmt::QOBLIBQS)
     end
 end
 
+function _qoblib_qs_stem(path::AbstractString)
+    name = basename(path)
+
+    if endswith(name, ".xz")
+        name = first(splitext(name))
+    end
+
+    if endswith(name, ".qs")
+        name = first(splitext(name))
+    end
+
+    return name
+end
+
+function _qoblib_solution_status(file::AbstractString)
+    stem = first(splitext(file))
+
+    if endswith(stem, ".opt")
+        return (stem = chop(stem; tail = 4), status = "optimal", proven_optimal = true)
+    elseif endswith(stem, ".bst")
+        return (stem = chop(stem; tail = 4), status = "best_known", proven_optimal = false)
+    else
+        return (stem = stem, status = "reference", proven_optimal = false)
+    end
+end
+
+function _qoblib_portfolio_key(stem::AbstractString)
+    name = startswith(stem, "uqo_") ? stem[5:end] : String(stem)
+    m = match(r"^(.*)_l([^_]+)$", name)
+
+    if isnothing(m)
+        return name
+    else
+        return "$(m.captures[1])|$(repr(parse(Float64, m.captures[2])))"
+    end
+end
+
+function _qoblib_solution_key(group, path::AbstractString)
+    stem = _qoblib_qs_stem(path)
+
+    if hasproperty(group, :solution_format) && group.solution_format == :assignments
+        return _qoblib_portfolio_key(stem)
+    else
+        return stem
+    end
+end
+
+function _qoblib_portfolio_variant(value::AbstractString)
+    variant = strip(value)
+
+    if variant == "orig"
+        return "orig"
+    else
+        return "s$(lpad(string(round(Int, parse(Float64, variant))), 2, '0'))"
+    end
+end
+
+function _qoblib_parse_markdown_number(value::AbstractString)
+    text = replace(strip(value), "\\" => "")
+    text = replace(text, "*" => "")
+    text = replace(text, "," => "")
+
+    if isempty(text) || text == "[TO FILL]"
+        return missing
+    end
+
+    return parse(Float64, text)
+end
+
+function _qoblib_portfolio_source_values(path::AbstractString)
+    values = Dict{String,Float64}()
+
+    if !isfile(path)
+        return values
+    end
+
+    for line in eachline(path)
+        text = strip(line)
+
+        if !startswith(text, "|") || occursin("---", text)
+            continue
+        end
+
+        cells = strip.(split(strip(text, ['|']), '|'))
+
+        if length(cells) < 6 || lowercase(cells[1]) == "a"
+            continue
+        end
+
+        source_value = _qoblib_parse_markdown_number(cells[6])
+
+        if ismissing(source_value)
+            continue
+        end
+
+        a = round(Int, parse(Float64, cells[1]))
+        t = round(Int, parse(Float64, cells[2]))
+        s = _qoblib_portfolio_variant(cells[3])
+        b = round(Int, parse(Float64, cells[4]))
+        lambda = parse(Float64, cells[5])
+        base = "a$(lpad(string(a), 3, '0'))_t$(t)_$(s)_b$(lpad(string(b), 3, '0'))"
+
+        values["$base|$(repr(lambda))"] = source_value
+    end
+
+    return values
+end
+
+function _qoblib_direct_solution_index(root_path::AbstractString, group)
+    index = Dict{String,Any}()
+    solution_path = joinpath(root_path, group.solution_path)
+
+    if !isdir(solution_path)
+        return index
+    end
+
+    for (root, _, files) in walkdir(solution_path)
+        for file in files
+            endswith(file, ".sol") || continue
+
+            status = _qoblib_solution_status(file)
+            path = joinpath(root, file)
+
+            index[status.stem] = (
+                kind = :file,
+                path = path,
+                member = nothing,
+                status = status.status,
+                proven_optimal = status.proven_optimal,
+                source_value = missing,
+            )
+        end
+    end
+
+    return index
+end
+
+function _qoblib_tar_solution_index(root_path::AbstractString, group)
+    @assert run(`which tar`, devnull, devnull).exitcode == 0 "'tar' is required to read QOBLIB solution archives"
+
+    index = Dict{String,Any}()
+    solution_path = joinpath(root_path, group.solution_path)
+    source_values = _qoblib_portfolio_source_values(joinpath(solution_path, "README.md"))
+
+    if !isdir(solution_path)
+        return index
+    end
+
+    for archive_path in
+        sort(filter(endswith(".tar.gz"), readdir(solution_path; join = true)))
+        listing = read(Cmd(["tar", "-tzf", archive_path]), String)
+
+        for member in eachsplit(listing, '\n')
+            member = strip(member)
+
+            if !endswith(member, ".sol")
+                continue
+            end
+
+            key = _qoblib_portfolio_key(first(splitext(basename(member))))
+
+            index[key] = (
+                kind = :tar,
+                path = archive_path,
+                member = member,
+                status = "best_known",
+                proven_optimal = false,
+                source_value = get(source_values, key, missing),
+            )
+        end
+    end
+
+    return index
+end
+
+function _qoblib_solution_index(root_path::AbstractString, group)
+    if !hasproperty(group, :solution_path)
+        return Dict{String,Any}()
+    elseif hasproperty(group, :solution_format) && group.solution_format == :assignments
+        return _qoblib_tar_solution_index(root_path, group)
+    else
+        return _qoblib_direct_solution_index(root_path, group)
+    end
+end
+
+function _qoblib_source_value(line::AbstractString)
+    m = match(
+        r"(?i)(?:energy|objective\s+value)\s*[:=]\s*([-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)",
+        line,
+    )
+
+    return isnothing(m) ? missing : parse(Float64, m.captures[1])
+end
+
+function _qoblib_parse_bit_tokens(lines::Vector{String})
+    tokens = String[]
+
+    for line in lines
+        append!(tokens, split(line))
+    end
+
+    return map(tokens) do token
+        if token == "0"
+            return 0
+        elseif token == "1"
+            return 1
+        else
+            QUBOTools.syntax_error("Invalid QOBLIB incumbent bit '$token'")
+        end
+    end
+end
+
+function _qoblib_read_bit_tokens(lines::Vector{String}, dimension::Integer)
+    state = _qoblib_parse_bit_tokens(lines)
+
+    if length(state) != dimension
+        QUBOTools.syntax_error(
+            "QOBLIB incumbent bitstring length mismatch: expected $dimension, got $(length(state))",
+        )
+    end
+
+    return state
+end
+
+function _qoblib_read_labs_bits(lines::Vector{String}, dimension::Integer)
+    state = _qoblib_parse_bit_tokens(lines)
+    n = length(state)
+    expected_dimension = n + div(n * (n - 1), 2)
+
+    if dimension != expected_dimension
+        QUBOTools.syntax_error(
+            "QOBLIB LABS incumbent dimension mismatch: expected $dimension, reconstructed $expected_dimension",
+        )
+    end
+
+    for i = 1:(n - 1)
+        for j = (i + 1):n
+            push!(state, state[i] * state[j])
+        end
+    end
+
+    return state
+end
+
+function _qoblib_read_active_indices(lines::Vector{String}, dimension::Integer)
+    state = zeros(Int, dimension)
+
+    for line in lines
+        for token in split(line)
+            index = _qoblib_parse_int(token)
+
+            if !(1 <= index <= dimension)
+                QUBOTools.syntax_error(
+                    "QOBLIB incumbent active index out of bounds: $index",
+                )
+            elseif state[index] == 1
+                QUBOTools.syntax_error("Duplicate QOBLIB incumbent active index: $index")
+            end
+
+            state[index] = 1
+        end
+    end
+
+    return state
+end
+
+function _qoblib_read_assignments(lines::Vector{String}, dimension::Integer)
+    state = fill(-1, dimension)
+
+    for line in lines
+        m = match(
+            r"^x#([0-9]+)\s+([-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)$",
+            strip(line),
+        )
+
+        if isnothing(m)
+            QUBOTools.syntax_error("Invalid QOBLIB incumbent assignment: $line")
+        end
+
+        index = _qoblib_parse_int(m.captures[1])
+        value = parse(Float64, m.captures[2])
+
+        if !(1 <= index <= dimension)
+            QUBOTools.syntax_error(
+                "QOBLIB incumbent assignment index out of bounds: $index",
+            )
+        end
+
+        bit = round(Int, value)
+
+        if !isapprox(value, bit; atol = 1e-9) || !(bit == 0 || bit == 1)
+            QUBOTools.syntax_error("Invalid QOBLIB incumbent assignment value: $value")
+        elseif state[index] != -1
+            QUBOTools.syntax_error("Duplicate QOBLIB incumbent assignment: x#$index")
+        end
+
+        state[index] = bit
+    end
+
+    missing = findfirst(==(-1), state)
+
+    if !isnothing(missing)
+        QUBOTools.syntax_error("Missing QOBLIB incumbent assignment: x#$missing")
+    end
+
+    return state
+end
+
+function _qoblib_read_solution(io::IO, format::Symbol, dimension::Integer)
+    lines = String[]
+    source_value = missing
+
+    for raw_line in eachline(io)
+        line = strip(raw_line)
+
+        isempty(line) && continue
+
+        if startswith(line, "#")
+            value = _qoblib_source_value(line)
+
+            if !ismissing(value)
+                source_value = value
+            end
+        else
+            push!(lines, line)
+        end
+    end
+
+    state = if format == :bit_tokens
+        _qoblib_read_bit_tokens(lines, dimension)
+    elseif format == :labs_bits
+        _qoblib_read_labs_bits(lines, dimension)
+    elseif format == :active_indices
+        _qoblib_read_active_indices(lines, dimension)
+    elseif format == :assignments
+        _qoblib_read_assignments(lines, dimension)
+    else
+        error("[qoblib] Unsupported incumbent solution format '$format'")
+    end
+
+    return (state = state, source_value = source_value)
+end
+
+function _qoblib_read_solution(info, format::Symbol, dimension::Integer)
+    if info.kind == :file
+        return open(info.path, "r") do io
+            _qoblib_read_solution(io, format, dimension)
+        end
+    elseif info.kind == :tar
+        return open(Cmd(["tar", "-xOzf", info.path, String(info.member)]), "r") do io
+            _qoblib_read_solution(io, format, dimension)
+        end
+    else
+        error("[qoblib] Unsupported incumbent source kind '$(info.kind)'")
+    end
+end
+
+function _qoblib_source_path(root_path::AbstractString, info)
+    source_path = replace(relpath(info.path, root_path), '\\' => '/')
+
+    if isnothing(info.member)
+        return source_path
+    else
+        return "$(source_path)!$(info.member)"
+    end
+end
+
+function _qoblib_source_url(root_path::AbstractString, info)
+    source_path = replace(relpath(info.path, root_path), '\\' => '/')
+
+    return "https://github.com/$(QOBLIB_REPOSITORY)/blob/$(QOBLIB_SOURCE_COMMIT)/$(source_path)"
+end
+
+function _qoblib_incumbent_metadata(
+    root_path::AbstractString,
+    group,
+    info;
+    source_value = missing,
+)
+    metadata = Dict{String,Any}(
+        "source_name"       => "QOBLIB",
+        "source_commit"     => QOBLIB_SOURCE_COMMIT,
+        "source_path"       => _qoblib_source_path(root_path, info),
+        "source_url"        => _qoblib_source_url(root_path, info),
+        "source_status"     => info.status,
+        "source_format"     => String(group.solution_format),
+        "validation_status" => "validated",
+        "qubo_value_source" => "QUBOTools.value(model, bitstring)",
+    )
+
+    if !ismissing(source_value)
+        metadata["source_value"] = source_value
+    end
+
+    if !isnothing(info.member)
+        metadata["source_member"] = info.member
+    end
+
+    return metadata
+end
+
+function _qoblib_missing_incumbent_metadata(
+    root_path::AbstractString,
+    group,
+    model_path::AbstractString,
+    key::AbstractString,
+)
+    return Dict{String,Any}(
+        "source_name"           => "QOBLIB",
+        "source_commit"         => QOBLIB_SOURCE_COMMIT,
+        "source_status"         => "missing",
+        "validation_status"     => "missing",
+        "reason"                => "missing_source_solution",
+        "expected_solution_key" => key,
+        "model_source_path"     => replace(relpath(model_path, root_path), '\\' => '/'),
+        "solution_path"         => hasproperty(group, :solution_path) ? group.solution_path : missing,
+        "source_format"         => hasproperty(group, :solution_format) ? String(group.solution_format) : missing,
+    )
+end
+
+function _add_qoblib_missing_incumbent!(
+    index::QUBOLib.LibraryIndex,
+    instance::Integer,
+    root_path::AbstractString,
+    group,
+    model_path::AbstractString,
+    key::AbstractString,
+)
+    QUBOLib.add_solution_record!(
+        index,
+        instance;
+        feasibility_status = "missing",
+        validation_status = "missing",
+        incumbent_candidate = false,
+        metadata = _qoblib_missing_incumbent_metadata(root_path, group, model_path, key),
+    )
+
+    return :missing
+end
+
+function _add_qoblib_incumbent!(
+    index::QUBOLib.LibraryIndex,
+    instance::Integer,
+    model::QUBOTools.Model{Int,Float64,Int},
+    root_path::AbstractString,
+    group,
+    model_path::AbstractString,
+    solution_index::Dict{String,Any},
+)
+    if !hasproperty(group, :solution_path)
+        return :skipped
+    end
+
+    key = _qoblib_solution_key(group, model_path)
+
+    if !haskey(solution_index, key)
+        return _add_qoblib_missing_incumbent!(
+            index,
+            instance,
+            root_path,
+            group,
+            model_path,
+            key,
+        )
+    end
+
+    info = solution_index[key]
+    dimension = QUBOTools.dimension(model)
+    solution = _qoblib_read_solution(info, group.solution_format, dimension)
+    source_value = ismissing(info.source_value) ? solution.source_value : info.source_value
+
+    if length(solution.state) != dimension
+        error(
+            "[qoblib] Incumbent dimension mismatch for '$model_path': " *
+            "expected $dimension, got $(length(solution.state))",
+        )
+    end
+
+    qubo_value = QUBOTools.value(model, solution.state)
+    metadata = _qoblib_incumbent_metadata(root_path, group, info; source_value)
+    sol = QUBOTools.SampleSet{Float64,Int}(model, [solution.state]; metadata)
+
+    if !isapprox(QUBOTools.value(sol, 1), qubo_value; rtol = 1e-8, atol = 1e-8)
+        error("[qoblib] HDF5 incumbent sample value does not match QUBO value")
+    end
+
+    QUBOLib.add_solution!(
+        index,
+        instance,
+        sol;
+        qubo_value,
+        source_value = ismissing(source_value) ? missing : source_value,
+        proven_optimal = info.proven_optimal,
+        feasibility_status = "feasible",
+        validation_status = "validated",
+        incumbent_candidate = true,
+        source_path = _qoblib_source_path(root_path, info),
+        metadata,
+    )
+
+    return :imported
+end
+
+function _validate_qoblib_incumbent_counts!(
+    group,
+    incumbent_count::Integer,
+    missing_incumbent_count::Integer,
+)
+    if !hasproperty(group, :expected_incumbents)
+        return nothing
+    end
+
+    expected_incumbents = group.expected_incumbents
+    expected_missing = group.expected_count - expected_incumbents
+
+    if incumbent_count != expected_incumbents
+        error(
+            "[qoblib] Expected $(expected_incumbents) incumbents for $(group.code), " *
+            "imported $incumbent_count",
+        )
+    elseif missing_incumbent_count != expected_missing
+        error(
+            "[qoblib] Expected $(expected_missing) missing incumbents for $(group.code), " *
+            "marked $missing_incumbent_count",
+        )
+    end
+
+    return nothing
+end
+
 function build_qoblib!(
     index::QUBOLib.LibraryIndex;
     cache::Bool = true,
@@ -281,11 +823,16 @@ function build_qoblib!(
     QUBOLib.add_collection!(index, QOBLIB_COLLECTION, QOBLIB_DATA)
 
     count = 0
+    incumbent_count = 0
+    missing_incumbent_count = 0
 
     for group in groups
         group_path = joinpath(root_path, group.path)
         metrics = _read_qoblib_metrics(joinpath(group_path, "metrics.csv"))
         model_paths = _qoblib_model_paths(group_path)
+        solution_index = _qoblib_solution_index(root_path, group)
+        group_incumbent_count = 0
+        group_missing_incumbent_count = 0
 
         if length(model_paths) != group.expected_count
             error(
@@ -301,7 +848,7 @@ function build_qoblib!(
             merge!(QUBOTools.metadata(model), metadata)
             _validate_qoblib_metrics!(model, metrics, model_path)
 
-            QUBOLib.add_instance!(
+            instance = QUBOLib.add_instance!(
                 index,
                 model,
                 QOBLIB_COLLECTION;
@@ -316,8 +863,32 @@ function build_qoblib!(
                 metadata          = metadata,
             )
 
+            incumbent_status = _add_qoblib_incumbent!(
+                index,
+                instance,
+                model,
+                root_path,
+                group,
+                model_path,
+                solution_index,
+            )
+
+            if incumbent_status == :imported
+                group_incumbent_count += 1
+                incumbent_count += 1
+            elseif incumbent_status == :missing
+                group_missing_incumbent_count += 1
+                missing_incumbent_count += 1
+            end
+
             count += 1
         end
+
+        _validate_qoblib_incumbent_counts!(
+            group,
+            group_incumbent_count,
+            group_missing_incumbent_count,
+        )
     end
 
     expected_count = sum(group.expected_count for group in groups)
@@ -325,6 +896,8 @@ function build_qoblib!(
     if count != expected_count
         error("[qoblib] Expected to import $expected_count QS models, imported $count")
     end
+
+    @info "[qoblib] Imported $incumbent_count incumbents; marked $missing_incumbent_count missing"
 
     return nothing
 end
@@ -428,6 +1001,16 @@ function _qoblib_archive_patterns(root::AbstractString, groups)
         else
             push!(patterns, "$root/$(group.path)/*.qs.xz")
         end
+
+        if hasproperty(group, :solution_path)
+            push!(patterns, "$root/$(group.solution_path)/README.md")
+
+            if hasproperty(group, :solution_format) && group.solution_format == :assignments
+                push!(patterns, "$root/$(group.solution_path)/*.tar.gz")
+            else
+                push!(patterns, "$root/$(group.solution_path)/*.sol")
+            end
+        end
     end
 
     return patterns
@@ -451,6 +1034,18 @@ function _validate_qoblib_source!(root_path::AbstractString, groups)
 
         for file in ("README.md", "metrics.csv")
             path = joinpath(group.path, file)
+
+            if !isfile(joinpath(root_path, path))
+                push!(missing, path)
+            end
+        end
+
+        if hasproperty(group, :solution_path)
+            if !isdir(joinpath(root_path, group.solution_path))
+                push!(missing, group.solution_path)
+            end
+
+            path = joinpath(group.solution_path, "README.md")
 
             if !isfile(joinpath(root_path, path))
                 push!(missing, path)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -116,7 +116,7 @@ Removes an instance from the library index.
 function remove_instance! end
 
 @doc raw"""
-    add_solution!(index::LibraryIndex, instance::Integer, solution::SampleSet{Float64,Int})
+    add_solution!(index::LibraryIndex, instance::Integer, solution::SampleSet{Float64,Int}; kwargs...)
 
 Registers a new solution for a given instance.
 

--- a/src/library/solutions.jl
+++ b/src/library/solutions.jl
@@ -357,16 +357,35 @@ function load_best_solution(index::LibraryIndex, instance::Integer)
     end
 end
 
-function add_solution!(index::LibraryIndex, instance::Integer, sol::QUBOTools.SampleSet{Float64,Int})::Integer
+function add_solution!(
+    index::LibraryIndex,
+    instance::Integer,
+    sol::QUBOTools.SampleSet{Float64,Int};
+    qubo_value = nothing,
+    source_value = nothing,
+    objective_bound = nothing,
+    proven_optimal = nothing,
+    feasibility_status = "feasible",
+    validation_status = nothing,
+    incumbent_candidate::Bool = true,
+    source_path = nothing,
+    metadata = nothing,
+)::Integer
     @assert isopen(index)
     @assert !isempty(sol)
 
-    data = QUBOTools.metadata(sol)
+    data = isnothing(metadata) ? QUBOTools.metadata(sol) : metadata
 
-    solver  = get(data, "solver", nothing)
-    value   = QUBOTools.value(sol, 1)
+    solver = get(data, "solver", nothing)
+    value  = QUBOTools.value(sol, 1)
 
-    optimal = get(data, "status", nothing) == "optimal"
+    optimal = if isnothing(proven_optimal)
+        get(data, "status", nothing) == "optimal"
+    else
+        proven_optimal
+    end
+
+    provenance_value = isnothing(source_value) ? value : source_value
 
     db = QUBOLib.database(index)
     h5 = QUBOLib.archive(index)
@@ -379,7 +398,7 @@ function add_solution!(index::LibraryIndex, instance::Integer, sol::QUBOTools.Sa
         VALUES
             (?, ?, ?, ?)   
         """,
-        (instance, solver, value, optimal)
+        (instance, solver, value, optimal),
     )
 
     i = DBInterface.lastrowid(query)::Integer
@@ -393,10 +412,14 @@ function add_solution!(index::LibraryIndex, instance::Integer, sol::QUBOTools.Sa
         instance;
         solution = i,
         bitstring = _solution_bitstring(sol),
-        source_value = value,
+        qubo_value,
+        source_value = provenance_value,
+        objective_bound,
         proven_optimal = optimal,
-        feasibility_status = "feasible",
-        incumbent_candidate = true,
+        feasibility_status,
+        validation_status,
+        incumbent_candidate,
+        source_path,
         metadata = data,
     )
 

--- a/src/library/solutions.jl
+++ b/src/library/solutions.jl
@@ -369,12 +369,11 @@ function add_solution!(
     validation_status = nothing,
     incumbent_candidate::Bool = true,
     source_path = nothing,
-    metadata = nothing,
 )::Integer
     @assert isopen(index)
     @assert !isempty(sol)
 
-    data = isnothing(metadata) ? QUBOTools.metadata(sol) : metadata
+    data = QUBOTools.metadata(sol)
 
     solver = get(data, "solver", nothing)
     value  = QUBOTools.value(sol, 1)

--- a/test/library/access.jl
+++ b/test/library/access.jl
@@ -97,6 +97,7 @@ function test_library_access()
                 @test best[:solution] == solution
                 @test QUBOTools.state(loaded_best[1]) == [0, 0, 0]
                 @test QUBOTools.value(loaded_best, 1) ≈ QUBOTools.value(sol, 1)
+                @test QUBOLib.JSON.parse(best[:metadata]) == QUBOTools.metadata(loaded_best)
             end
         end
     end


### PR DESCRIPTION
## Summary

- Import QOBLIB incumbent/reference bitstrings during the QOBLIB build and register them as HDF5 samples plus `SolutionRecords`.
- Reconstruct QUBO-space bitstrings for LABS auxiliary product variables, active-index solutions, and portfolio assignment archives before evaluating `qubo_value`.
- Preserve source values/status metadata separately from QUBO ranking values, and mark QOBLIB models without source solutions as missing-incumbent records.

## Tests run

- `julia --project=scripts/build --load scripts/build/runtests.jl --eval 'test_qoblib_qs_parser(); test_qoblib_build_fixture()'`
  - Passed: QOBLIB QS parser 15/15, QOBLIB build fixture 33/33.
- `julia --project=scripts/build --load scripts/build/build.jl --eval 'mktempdir() do path; QUBOLib.access(; path, clear = true) do index; build_qoblib!(index; source_path = "/tmp/qoblib-80e45c176fc6281e5316451f02296482934785fa.zip", cache = false); db = QUBOLib.database(index); counts = QUBOLib.DBInterface.execute(db, """SELECT i.problem_class, COUNT(*) AS models, COUNT(b.record) AS incumbents, SUM(CASE WHEN r.validation_status = '\''missing'\'' THEN 1 ELSE 0 END) AS missing FROM Instances AS i LEFT JOIN BestSolutions AS b ON b.instance = i.instance LEFT JOIN SolutionRecords AS r ON r.instance = i.instance WHERE i.collection = '\''qoblib'\'' GROUP BY i.problem_class ORDER BY i.problem_class;""") |> QUBOLib.DataFrame; println(counts); end; end'`
  - Passed pinned-source validation: LABS 99/99 incumbents, Market Split 115/156 incumbents with 41 missing, Maximum Independent Set 50/50 incumbents, Portfolio Optimization 128/128 incumbents.
- `julia --project=. -e 'import Pkg; Pkg.test()'`
  - Passed: 73/73.
- `git diff --check`
  - Passed.

## Tests not run / notes

- `make test-build` was run and failed only in the existing tag test: `next_data_tag("v1.2.3-data+2")` evaluated to `"v0.1.0-data+3"` instead of `"v1.2.3-data+3"`. The changed QOBLIB parser and build fixture testsets in that target passed 15/15 and 33/33.
- I did not find separate documented lint or type-check targets in README, CI, or Makefile.

Closes #17
