### PR TITLE
Document benchmarking workflow

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,13 @@
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 QUBOLib = "c2d3eca2-2309-4628-88a9-9d4a554e7c47"
+QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
+SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 
 [compat]
+DataFrames = "1"
 Documenter = "1"
+QUBOTools = "0.10, 0.12"
+SQLite = "1"

--- a/docs/src/manual/0-intro.md
+++ b/docs/src/manual/0-intro.md
@@ -69,10 +69,11 @@ The usual workflow is:
 The self-contained example below creates a tiny local benchmark library so the
 workflow is exercised as part of the documentation build. In normal use, open
 the packaged artifact with `QUBOLib.access()` and start from the SQL query. The
-example selects one instance that has an incumbent, evaluates a candidate
-bitstring, compares it with the incumbent `qubo_value`, and inspects the related
-provenance. It uses SQLite.jl, DataFrames.jl, and QUBOTools.jl directly, so add
-them to the active Julia project before running similar scripts.
+example registers two benchmark instances with incumbents, evaluates two
+candidate methods on each instance, compares their values with the incumbent
+`qubo_value`, and inspects the related provenance. It uses SQLite.jl,
+DataFrames.jl, and QUBOTools.jl directly, so add them to the active Julia
+project before running similar scripts.
 
 ```@example benchmarking-workflow
 using QUBOLib
@@ -80,33 +81,55 @@ using SQLite, DataFrames
 import QUBOTools
 
 result = mktempdir() do root
-    model = QUBOTools.Model(
-        Dict(1 => 1.0, 2 => -2.0),
-        Dict{Tuple{Int,Int},Float64}((1, 2) => 0.5),
+    instances = (
+        (
+            name = "tiny-a",
+            model = QUBOTools.Model(
+                Dict(1 => 1.0, 2 => -2.0),
+                Dict{Tuple{Int,Int},Float64}((1, 2) => 0.5),
+            ),
+            incumbent_state = [0, 1],
+            source_value = 123.0,
+        ),
+        (
+            name = "tiny-b",
+            model = QUBOTools.Model(
+                Dict(1 => -1.0, 2 => 0.5, 3 => 2.0),
+                Dict{Tuple{Int,Int},Float64}((1, 2) => -0.25, (2, 3) => 1.0),
+            ),
+            incumbent_state = [1, 0, 0],
+            source_value = 456.0,
+        ),
+    )
+    methods = (
+        (name = "zero-fill", state = n -> fill(0, n)),
+        (name = "one-fill", state = n -> fill(1, n)),
     )
 
     QUBOLib.access(; path = root, clear = true) do index
-        instance_id = QUBOLib.add_instance!(index, model; name = "tiny-benchmark")
-        submission = QUBOLib.add_submission!(
-            index;
-            submitter = "example solver",
-            workflow = "QUBO-space heuristic",
-            hardware = "local CPU",
-        )
+        for data in instances
+            instance_id = QUBOLib.add_instance!(index, data.model; name = data.name)
+            submission = QUBOLib.add_submission!(
+                index;
+                submitter = "reference incumbent",
+                workflow = "curated QUBO-space reference",
+                hardware = "local CPU",
+            )
 
-        incumbent_solution = QUBOTools.SampleSet{Float64,Int}(
-            model,
-            [[0, 1]];
-            metadata = Dict{String,Any}("status" => "best_known"),
-        )
-        QUBOLib.add_solution!(
-            index,
-            instance_id,
-            incumbent_solution;
-            submission,
-            source_value = 123.0,
-            validation_status = "validated",
-        )
+            incumbent_solution = QUBOTools.SampleSet{Float64,Int}(
+                data.model,
+                [data.incumbent_state];
+                metadata = Dict{String,Any}("status" => "best_known"),
+            )
+            QUBOLib.add_solution!(
+                index,
+                instance_id,
+                incumbent_solution;
+                submission,
+                source_value = data.source_value,
+                validation_status = "validated",
+            )
+        end
 
         db = QUBOLib.database(index)
 
@@ -118,47 +141,52 @@ result = mktempdir() do root
             JOIN BestSolutions AS b
               ON b.instance = i.instance
             ORDER BY i.dimension, i.instance
-            LIMIT 1;
+            LIMIT 2;
             """,
         ) |> DataFrame
 
-        instance = only(selected[!, :instance])
-        model = QUBOLib.load_instance(index, instance)
+        rows = NamedTuple[]
 
-        incumbent_record = QUBOLib.best_solution_record(index, instance)
-        incumbent_sample = QUBOLib.load_best_solution(index, instance)
+        for instance_row in eachrow(selected), method in methods
+            instance = instance_row[:instance]
+            model = QUBOLib.load_instance(index, instance)
+            incumbent_record = QUBOLib.best_solution_record(index, instance)
+            incumbent_sample = QUBOLib.load_best_solution(index, instance)
 
-        candidate_state = fill(0, only(selected[!, :dimension]))
-        candidate_value = QUBOTools.value(model, candidate_state)
-
-        incumbent_value = incumbent_record[:qubo_value]
-        absolute_gap = candidate_value - incumbent_value
-        relative_gap = absolute_gap / max(1.0, abs(incumbent_value))
-
-        all_records = QUBOLib.list_solution_records(index, instance)
-        provenance = if ismissing(incumbent_record[:submission])
-            DataFrame()
-        else
-            DBInterface.execute(
+            candidate_state = method.state(instance_row[:dimension])
+            candidate_value = QUBOTools.value(model, candidate_state)
+            incumbent_value = incumbent_record[:qubo_value]
+            absolute_gap = candidate_value - incumbent_value
+            relative_gap = absolute_gap / max(1.0, abs(incumbent_value))
+            records = QUBOLib.list_solution_records(index, instance)
+            provenance = DBInterface.execute(
                 db,
                 """
-                SELECT submitter, date, reference, workflow, hardware, total_runtime
+                SELECT submitter, workflow
                 FROM Submissions
                 WHERE submission = ?;
                 """,
                 (incumbent_record[:submission],),
             ) |> DataFrame
+
+            push!(
+                rows,
+                (
+                    instance = instance_row[:name],
+                    method = method.name,
+                    candidate_value = candidate_value,
+                    incumbent_value = incumbent_value,
+                    incumbent_sample_value = QUBOTools.value(incumbent_sample, 1),
+                    source_value = incumbent_record[:source_value],
+                    absolute_gap = absolute_gap,
+                    relative_gap = relative_gap,
+                    solution_records = size(records, 1),
+                    incumbent_submitter = only(provenance[!, :submitter]),
+                ),
+            )
         end
 
-        return (
-            candidate_value = candidate_value,
-            incumbent_value = incumbent_value,
-            incumbent_sample_value = QUBOTools.value(incumbent_sample, 1),
-            absolute_gap = absolute_gap,
-            relative_gap = relative_gap,
-            records = size(all_records, 1),
-            submitter = only(provenance[!, :submitter]),
-        )
+        return DataFrame(rows)
     end
 end
 

--- a/docs/src/manual/0-intro.md
+++ b/docs/src/manual/0-intro.md
@@ -1,5 +1,19 @@
 # Introduction
 
+## Mathematical Definitions
+
+All instances have been recast into the binary, minimization form:
+
+```math
+\begin{array}{rll}
+    \displaystyle
+    \min_{\mathbf{x}} & \alpha \left[ \mathbf{x}' \mathbf{Q} \, \mathbf{x} + \mathbf{\ell}' \mathbf{x} + \beta \right] \\
+    \textrm{s.t.}     & \mathbf{x} \in \mathbb{B}^{n} \\
+\end{array}
+```
+
+where ``\mathbf{Q} \in \mathbb{R}^{n \times n}`` is an upper triangular matrix, ``\mathbf{\ell} \in \mathbb{R}^{n}`` is a vector, ``\alpha, \beta \in \mathbb{R}`` are scalars, and ``\mathbb{B}^{n}`` is the set of binary vectors of length ``n``.
+
 ## Benchmarking Physics-Inspired Optimization Solvers
 
 QUBOLib is meant to make QUBO solver comparisons reproducible at the
@@ -118,7 +132,19 @@ QUBOLib.access() do index
 end
 ```
 
-For the minimization QUBOs described below, smaller `qubo_value` values are
+For solver stacks such as QUBODrivers, or for any other package that returns a
+QUBO-space state, keep the solver-specific call separate from the QUBOLib
+comparison step. Once the solver output has been converted to a binary vector in
+the variable order of `model`, the comparison is the same:
+
+```julia
+# candidate_state should be a Vector{Int} in the variable order of `model`.
+candidate_value = QUBOTools.value(model, candidate_state)
+incumbent_record = QUBOLib.best_solution_record(index, instance)
+absolute_gap = candidate_value - incumbent_record[:qubo_value]
+```
+
+For the minimization QUBOs described above, smaller `qubo_value` values are
 better, so a positive absolute gap means the candidate is worse than the current
 incumbent. When writing generic reports, check the instance `sense` metadata and
 apply the matching sign convention consistently.
@@ -136,20 +162,6 @@ QOBLIB-derived records should be attributed through their collection,
 submission, source path, reference, and metadata fields. Their original
 `source_value` is preserved when available, but QUBOLib benchmarking uses the
 mapped bitstring and locally evaluated `qubo_value`.
-
-## Mathematical Definitions
-
-All instances have been recast into the binary, minimization form:
-
-```math
-\begin{array}{rll}
-    \displaystyle
-    \min_{\mathbf{x}} & \alpha \left[ \mathbf{x}' \mathbf{Q} \, \mathbf{x} + \mathbf{\ell}' \mathbf{x} + \beta \right] \\
-    \textrm{s.t.}     & \mathbf{x} \in \mathbb{B}^{n} \\
-\end{array}
-```
-
-where ``\mathbf{Q} \in \mathbb{R}^{n \times n}`` is an upper triangular matrix, ``\mathbf{\ell} \in \mathbb{R}^{n}`` is a vector, ``\alpha, \beta \in \mathbb{R}`` are scalars, and ``\mathbb{B}^{n}`` is the set of binary vectors of length ``n``.
 
 ## Table of Contents
 

--- a/docs/src/manual/0-intro.md
+++ b/docs/src/manual/0-intro.md
@@ -66,70 +66,103 @@ The usual workflow is:
 7. Inspect `QUBOLib.list_solution_records` and the linked `Submissions` row when
    reporting provenance, feasibility, validation, or attribution.
 
-The example below selects one instance that has an incumbent, evaluates a
-candidate bitstring, compares it with the incumbent `qubo_value`, and inspects
-the related provenance. It uses SQLite.jl and DataFrames.jl directly, so add
-them to the active Julia project before running it.
+The self-contained example below creates a tiny local benchmark library so the
+workflow is exercised as part of the documentation build. In normal use, open
+the packaged artifact with `QUBOLib.access()` and start from the SQL query. The
+example selects one instance that has an incumbent, evaluates a candidate
+bitstring, compares it with the incumbent `qubo_value`, and inspects the related
+provenance. It uses SQLite.jl, DataFrames.jl, and QUBOTools.jl directly, so add
+them to the active Julia project before running similar scripts.
 
-```julia
+```@example benchmarking-workflow
 using QUBOLib
 using SQLite, DataFrames
 import QUBOTools
 
-QUBOLib.access() do index
-    db = QUBOLib.database(index)
+result = mktempdir() do root
+    model = QUBOTools.Model(
+        Dict(1 => 1.0, 2 => -2.0),
+        Dict{Tuple{Int,Int},Float64}((1, 2) => 0.5),
+    )
 
-    selected = DBInterface.execute(
-        db,
-        """
-        SELECT i.instance, i.collection, i.name, i.dimension
-        FROM Instances AS i
-        JOIN BestSolutions AS b
-          ON b.instance = i.instance
-        ORDER BY i.dimension, i.instance
-        LIMIT 1;
-        """,
-    ) |> DataFrame
+    QUBOLib.access(; path = root, clear = true) do index
+        instance_id = QUBOLib.add_instance!(index, model; name = "tiny-benchmark")
+        submission = QUBOLib.add_submission!(
+            index;
+            submitter = "example solver",
+            workflow = "QUBO-space heuristic",
+            hardware = "local CPU",
+        )
 
-    instance = only(selected[!, :instance])
-    model = QUBOLib.load_instance(index, instance)
+        incumbent_solution = QUBOTools.SampleSet{Float64,Int}(
+            model,
+            [[0, 1]];
+            metadata = Dict{String,Any}("status" => "best_known"),
+        )
+        QUBOLib.add_solution!(
+            index,
+            instance_id,
+            incumbent_solution;
+            submission,
+            source_value = 123.0,
+            validation_status = "validated",
+        )
 
-    incumbent_record = QUBOLib.best_solution_record(index, instance)
-    incumbent_sample = QUBOLib.load_best_solution(index, instance)
+        db = QUBOLib.database(index)
 
-    candidate_state = fill(0, only(selected[!, :dimension]))
-    candidate_value = QUBOTools.value(model, candidate_state)
-
-    incumbent_value = incumbent_record[:qubo_value]
-    absolute_gap = candidate_value - incumbent_value
-    relative_gap = absolute_gap / max(1.0, abs(incumbent_value))
-
-    all_records = QUBOLib.list_solution_records(index, instance)
-    provenance = if ismissing(incumbent_record[:submission])
-        DataFrame()
-    else
-        DBInterface.execute(
+        selected = DBInterface.execute(
             db,
             """
-            SELECT submitter, date, reference, workflow, hardware, total_runtime
-            FROM Submissions
-            WHERE submission = ?;
+            SELECT i.instance, i.collection, i.name, i.dimension
+            FROM Instances AS i
+            JOIN BestSolutions AS b
+              ON b.instance = i.instance
+            ORDER BY i.dimension, i.instance
+            LIMIT 1;
             """,
-            (incumbent_record[:submission],),
         ) |> DataFrame
-    end
 
-    return (
-        selected = selected,
-        candidate_value = candidate_value,
-        incumbent_value = incumbent_value,
-        absolute_gap = absolute_gap,
-        relative_gap = relative_gap,
-        incumbent_sample = incumbent_sample,
-        all_records = all_records,
-        provenance = provenance,
-    )
+        instance = only(selected[!, :instance])
+        model = QUBOLib.load_instance(index, instance)
+
+        incumbent_record = QUBOLib.best_solution_record(index, instance)
+        incumbent_sample = QUBOLib.load_best_solution(index, instance)
+
+        candidate_state = fill(0, only(selected[!, :dimension]))
+        candidate_value = QUBOTools.value(model, candidate_state)
+
+        incumbent_value = incumbent_record[:qubo_value]
+        absolute_gap = candidate_value - incumbent_value
+        relative_gap = absolute_gap / max(1.0, abs(incumbent_value))
+
+        all_records = QUBOLib.list_solution_records(index, instance)
+        provenance = if ismissing(incumbent_record[:submission])
+            DataFrame()
+        else
+            DBInterface.execute(
+                db,
+                """
+                SELECT submitter, date, reference, workflow, hardware, total_runtime
+                FROM Submissions
+                WHERE submission = ?;
+                """,
+                (incumbent_record[:submission],),
+            ) |> DataFrame
+        end
+
+        return (
+            candidate_value = candidate_value,
+            incumbent_value = incumbent_value,
+            incumbent_sample_value = QUBOTools.value(incumbent_sample, 1),
+            absolute_gap = absolute_gap,
+            relative_gap = relative_gap,
+            records = size(all_records, 1),
+            submitter = only(provenance[!, :submitter]),
+        )
+    end
 end
+
+result
 ```
 
 For solver stacks such as QUBODrivers, or for any other package that returns a

--- a/docs/src/manual/0-intro.md
+++ b/docs/src/manual/0-intro.md
@@ -2,6 +2,141 @@
 
 ## Benchmarking Physics-Inspired Optimization Solvers
 
+QUBOLib is meant to make QUBO solver comparisons reproducible at the
+benchmarking boundary: every solver output is compared as a full bitstring in
+the imported QUBO variable order, and the comparison value is the locally
+evaluated QUBO objective. This is useful for physics-inspired and heuristic
+optimizers because the same instance can be attacked by simulated annealers,
+quantum annealers, tensor-network heuristics, classical MIP solvers, or
+source-domain codes while still being scored against one canonical QUBO model.
+
+The library stores benchmark data in four related layers:
+
+- `Instances` are the canonical QUBO models stored in the SQLite/HDF5 library.
+  Their metadata is useful for selecting benchmark sets by collection,
+  dimension, density, source name, problem class, or formulation.
+- `Submissions` describe provenance for a run or reference source: who produced
+  it, when, with which method, hardware, runtime, reporting context, source
+  path, and supporting metadata.
+- `SolutionRecords` store submitted or reference QUBO-space bitstrings, their
+  computed `qubo_value`, optional `source_value`, validation and feasibility
+  status, optimality claims, and links to submission provenance.
+- `BestSolutions` is the curated incumbent view. It selects the current
+  best-known valid incumbent record for each instance and is the comparison
+  target exposed through `QUBOLib.best_solution_record` and
+  `QUBOLib.load_best_solution`.
+
+The canonical benchmark comparator is `qubo_value`: the value obtained by
+evaluating the full bitstring against the QUBO model stored in QUBOLib. A
+solution may originate from a source-domain solver, a classical MIP solve, a
+QOBLIB reference solution, or another external workflow. It can still be used
+for QUBO benchmarking once its state is mapped into the imported QUBO variable
+order and validated against the stored QUBO model. `source_value` is provenance
+only. It may differ from `qubo_value` because of source objective sign, offsets,
+penalties, auxiliary variables, or formulation conventions, so benchmark tables
+and gap calculations should use `qubo_value`.
+
+### Incumbent comparison workflow
+
+The usual workflow is:
+
+1. Query the SQLite index for instances with the metadata needed by an
+   experiment.
+2. Load each QUBO model with `QUBOLib.load_instance`.
+3. Convert the solver output to a binary vector or bitstring in the same
+   variable order.
+4. Evaluate the candidate with `QUBOTools.value`.
+5. Load the incumbent record with `QUBOLib.best_solution_record`, and optionally
+   load its stored sample set with `QUBOLib.load_best_solution`.
+6. Compare the candidate value to the incumbent record's `qubo_value`.
+7. Inspect `QUBOLib.list_solution_records` and the linked `Submissions` row when
+   reporting provenance, feasibility, validation, or attribution.
+
+The example below selects one instance that has an incumbent, evaluates a
+candidate bitstring, compares it with the incumbent `qubo_value`, and inspects
+the related provenance. It uses SQLite.jl and DataFrames.jl directly, so add
+them to the active Julia project before running it.
+
+```julia
+using QUBOLib
+using SQLite, DataFrames
+import QUBOTools
+
+QUBOLib.access() do index
+    db = QUBOLib.database(index)
+
+    selected = DBInterface.execute(
+        db,
+        """
+        SELECT i.instance, i.collection, i.name, i.dimension
+        FROM Instances AS i
+        JOIN BestSolutions AS b
+          ON b.instance = i.instance
+        ORDER BY i.dimension, i.instance
+        LIMIT 1;
+        """,
+    ) |> DataFrame
+
+    instance = only(selected[!, :instance])
+    model = QUBOLib.load_instance(index, instance)
+
+    incumbent_record = QUBOLib.best_solution_record(index, instance)
+    incumbent_sample = QUBOLib.load_best_solution(index, instance)
+
+    candidate_state = fill(0, only(selected[!, :dimension]))
+    candidate_value = QUBOTools.value(model, candidate_state)
+
+    incumbent_value = incumbent_record[:qubo_value]
+    absolute_gap = candidate_value - incumbent_value
+    relative_gap = absolute_gap / max(1.0, abs(incumbent_value))
+
+    all_records = QUBOLib.list_solution_records(index, instance)
+    provenance = if ismissing(incumbent_record[:submission])
+        DataFrame()
+    else
+        DBInterface.execute(
+            db,
+            """
+            SELECT submitter, date, reference, workflow, hardware, total_runtime
+            FROM Submissions
+            WHERE submission = ?;
+            """,
+            (incumbent_record[:submission],),
+        ) |> DataFrame
+    end
+
+    return (
+        selected = selected,
+        candidate_value = candidate_value,
+        incumbent_value = incumbent_value,
+        absolute_gap = absolute_gap,
+        relative_gap = relative_gap,
+        incumbent_sample = incumbent_sample,
+        all_records = all_records,
+        provenance = provenance,
+    )
+end
+```
+
+For the minimization QUBOs described below, smaller `qubo_value` values are
+better, so a positive absolute gap means the candidate is worse than the current
+incumbent. When writing generic reports, check the instance `sense` metadata and
+apply the matching sign convention consistently.
+
+`proven_optimal` records whether the incumbent is known or claimed to be
+optimal, not whether every future solver comparison should stop there.
+`validation_status` records whether the bitstring was evaluated, validated, or
+verified against the stored model. `feasibility_status` records whether the
+source workflow considered the result feasible, missing, unavailable,
+withdrawn, unmapped, or invalid. QUBOLib keeps non-incumbent records so reports
+can distinguish a high-quality validated incumbent from a rejected or
+unmapped source-domain result.
+
+QOBLIB-derived records should be attributed through their collection,
+submission, source path, reference, and metadata fields. Their original
+`source_value` is preserved when available, but QUBOLib benchmarking uses the
+mapped bitstring and locally evaluated `qubo_value`.
+
 ## Mathematical Definitions
 
 All instances have been recast into the binary, minimization form:

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -34,6 +34,8 @@ function test_docs()
         @test occursin("`source_value` is provenance", intro)
         @test occursin("solver stacks such as QUBODrivers", intro)
         @test occursin("```@example benchmarking-workflow", intro)
+        @test occursin("zero-fill", intro)
+        @test occursin("one-fill", intro)
 
         @test occursin("Opening the library index", basic)
         @test occursin("Loading an instance", basic)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -13,6 +13,13 @@ function test_docs()
         @test occursin("Pkg.add([\"SQLite\", \"DataFrames\"])", docs_home)
         @test occursin("donate challenging QUBOs", docs_home)
 
+        math_heading = findfirst("## Mathematical Definitions", intro)
+        benchmark_heading =
+            findfirst("## Benchmarking Physics-Inspired Optimization Solvers", intro)
+
+        @test !isnothing(math_heading)
+        @test !isnothing(benchmark_heading)
+        @test first(math_heading) < first(benchmark_heading)
         @test occursin("Benchmarking Physics-Inspired Optimization Solvers", intro)
         @test occursin("Instances", intro)
         @test occursin("Submissions", intro)
@@ -25,6 +32,7 @@ function test_docs()
         @test occursin("QUBOLib.list_solution_records", intro)
         @test occursin("canonical benchmark comparator is `qubo_value`", intro)
         @test occursin("`source_value` is provenance", intro)
+        @test occursin("solver stacks such as QUBODrivers", intro)
 
         @test occursin("Opening the library index", basic)
         @test occursin("Loading an instance", basic)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -33,6 +33,7 @@ function test_docs()
         @test occursin("canonical benchmark comparator is `qubo_value`", intro)
         @test occursin("`source_value` is provenance", intro)
         @test occursin("solver stacks such as QUBODrivers", intro)
+        @test occursin("```@example benchmarking-workflow", intro)
 
         @test occursin("Opening the library index", basic)
         @test occursin("Loading an instance", basic)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1,6 +1,7 @@
 function test_docs()
     @testset "-> Website docs" begin
         docs_home = read(joinpath(QUBOLib.root_path(), "docs", "src", "index.md"), String)
+        intro = read(joinpath(QUBOLib.root_path(), "docs", "src", "manual", "0-intro.md"), String)
         basic = read(joinpath(QUBOLib.root_path(), "docs", "src", "manual", "1-basic.md"), String)
         advanced = read(joinpath(QUBOLib.root_path(), "docs", "src", "manual", "2-advanced.md"), String)
 
@@ -11,6 +12,19 @@ function test_docs()
         @test occursin("delete the local `qubolib`", docs_home)
         @test occursin("Pkg.add([\"SQLite\", \"DataFrames\"])", docs_home)
         @test occursin("donate challenging QUBOs", docs_home)
+
+        @test occursin("Benchmarking Physics-Inspired Optimization Solvers", intro)
+        @test occursin("Instances", intro)
+        @test occursin("Submissions", intro)
+        @test occursin("SolutionRecords", intro)
+        @test occursin("BestSolutions", intro)
+        @test occursin("QUBOLib.load_instance", intro)
+        @test occursin("QUBOTools.value", intro)
+        @test occursin("QUBOLib.load_best_solution", intro)
+        @test occursin("QUBOLib.best_solution_record", intro)
+        @test occursin("QUBOLib.list_solution_records", intro)
+        @test occursin("canonical benchmark comparator is `qubo_value`", intro)
+        @test occursin("`source_value` is provenance", intro)
 
         @test occursin("Opening the library index", basic)
         @test occursin("Loading an instance", basic)


### PR DESCRIPTION
## Summary

- Fill the previously empty benchmarking section in the introduction docs.
- Document the `Instances`, `Submissions`, `SolutionRecords`, and `BestSolutions` layers.
- Add an incumbent-comparison example using SQLite/DataFrames, `QUBOLib.load_instance`, `QUBOLib.load_best_solution`, `QUBOLib.best_solution_record`, `QUBOLib.list_solution_records`, and `QUBOTools.value`.
- Clarify that benchmark comparisons use canonical QUBO-space `qubo_value`, while `source_value` is provenance only.
- Add docs tests for the new benchmarking content and key API names.

## Tests run

- `julia --project -e 'import Pkg; Pkg.test()'` - passed: 86 tests.
- `julia --project=docs docs/make.jl --skip-deploy` - passed; emitted existing warnings about docstrings not included in the manual and the expected skipped deployment warning.
- `git diff --check` - passed.

## Notes

- No separate lint, type-check, or formatting commands were found in README, CI, Makefile, or project files.

Closes #11
