### PR TITLE
Update QUBOLib artifact metadata for QOBLIB data

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,7 +1,7 @@
 [qubolib]
-git-tree-sha1 = "6700e412b5a7a4daff870df54bdb07412d106f55"
+git-tree-sha1 = "e27d0d1526f3491102ff447293b4be3725314db8"
 lazy          = true
 
     [[qubolib.download]]
-    url    = "https://github.com/JuliaQUBO/QUBOLib.jl/releases/download/v0.1.0-data+1/qubolib.tar.gz"
-    sha256 = "e980c50d146ff87ba31720587cb1e871522b8147ac01a762edf4a7a0a2b406de"
+    url    = "https://github.com/JuliaQUBO/QUBOLib.jl/releases/download/v0.1.0-data+2/qubolib.tar.gz"
+    sha256 = "e3826af0c2b7bed712b787304a28c57ff8fbb93543ef8c38fca1d8391a777387"


### PR DESCRIPTION
Summary

- Updated the tracked `qubolib` artifact metadata to the rebuilt QOBLIB-containing data artifact at `v0.1.0-data+2`.
- Published the matching `v0.1.0-data+2` release asset from the generated `dist/build/qubolib.tar.gz`.
- Verified the packaged artifact exposes QOBLIB instances, incumbent records, missing-incumbent metadata, and loadable best solutions.

Tests

- `julia --project=scripts/build scripts/build/script.jl --deploy --clear-build`: passed; generated `v0.1.0-data+2`, imported 392 QOBLIB incumbents, and marked 41 missing records.
- `make test-build`: passed, 96 tests.
- `julia --project -e 'import Pkg; Pkg.test(; coverage=false)'`: passed, 93 tests.
- `make docs`: no-op because the `docs/` directory shadows the make target.
- `julia --project=docs docs/make.jl --skip-deploy`: passed with existing warnings for 4 docstrings not included in the manual.
- `git diff --check`: passed.
- `julia --project -e "using QUBOLib, DataFrames; mktempdir() do path; QUBOLib.access(; path) do index; db = QUBOLib.database(index); scalar(sql) = only((QUBOLib.DBInterface.execute(db, sql) |> DataFrame)[!, :n]); qoblib_instances = scalar(\"SELECT COUNT(*) AS n FROM Instances WHERE source_name = 'QOBLIB';\"); qoblib_best = scalar(\"SELECT COUNT(*) AS n FROM BestSolutions AS b JOIN Instances AS i ON i.instance = b.instance WHERE i.source_name = 'QOBLIB';\"); qoblib_missing = scalar(\"SELECT COUNT(*) AS n FROM SolutionRecords AS r JOIN Instances AS i ON i.instance = r.instance WHERE i.source_name = 'QOBLIB' AND r.validation_status = 'missing';\"); rows = QUBOLib.DBInterface.execute(db, \"SELECT b.instance FROM BestSolutions AS b JOIN Instances AS i ON i.instance = b.instance WHERE i.source_name = 'QOBLIB' ORDER BY b.instance LIMIT 1;\") |> DataFrame; instance = only(rows[!, :instance]); loaded = QUBOLib.load_best_solution(index, instance); println(\"qoblib_instances=\" * string(qoblib_instances)); println(\"qoblib_best=\" * string(qoblib_best)); println(\"qoblib_missing=\" * string(qoblib_missing)); println(\"loaded_best_solution_empty=\" * string(isempty(loaded))); end; end"`: passed with `qoblib_instances=433`, `qoblib_best=392`, `qoblib_missing=41`, `loaded_best_solution_empty=false`.

Notes

- Artifact tree hash: `e27d0d1526f3491102ff447293b4be3725314db8`.
- Release asset sha256: `e3826af0c2b7bed712b787304a28c57ff8fbb93543ef8c38fca1d8391a777387`.
- Release: https://github.com/JuliaQUBO/QUBOLib.jl/releases/tag/v0.1.0-data%2B2
- Issue: Closes #19.
