### PR TITLE
Prepare QUBOLib 0.1.1 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBOLib"
 uuid = "c2d3eca2-2309-4628-88a9-9d4a554e7c47"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/scripts/build/runtests.jl
+++ b/scripts/build/runtests.jl
@@ -4,15 +4,19 @@ include("build.jl")
 
 function test_tags()
     @testset "▶ Tags" begin
-        @test next_data_tag("v0.1.0") == "v0.1.0-data+1"
-        @test next_data_tag("v1.2.3-data+2") == "v0.1.0-data+3"
+        data_tag(n) = let version = QUBOLib.__version__()
+            "v$(VersionNumber(version.major, version.minor, version.patch, ("data",), (n,)))"
+        end
+
+        @test next_data_tag("v0.1.0") == data_tag(1)
+        @test next_data_tag("v1.2.3-data+2") == data_tag(3)
 
         mktempdir() do path
             mkpath(QUBOLib.build_path(path))
             write(joinpath(QUBOLib.build_path(path), "last.tag"), "v0.1.0-data+7\n")
 
             @test last_data_tag(path) == "v0.1.0-data+7"
-            @test next_data_tag(last_data_tag(path)) == "v0.1.0-data+8"
+            @test next_data_tag(last_data_tag(path)) == data_tag(8)
         end
 
         mktempdir() do path
@@ -30,7 +34,7 @@ function test_tags()
             )
 
             @test last_data_tag(path) == "v0.1.0-data+5"
-            @test next_data_tag(last_data_tag(path)) == "v0.1.0-data+6"
+            @test next_data_tag(last_data_tag(path)) == data_tag(6)
         end
     end
 

--- a/test/project.jl
+++ b/test/project.jl
@@ -1,0 +1,18 @@
+function _compat_allows(compat::AbstractString, version::VersionNumber)
+    specs = split(compat, ',')
+
+    return any(specs) do spec
+        version in QUBOLib.Pkg.Types.VersionSpec(strip(spec))
+    end
+end
+
+function test_project_metadata()
+    @testset "Project metadata" begin
+        project = QUBOLib.TOML.parsefile(joinpath(pkgdir(QUBOLib), "Project.toml"))
+
+        @test QUBOLib.__version__() == VersionNumber(project["version"])
+        @test _compat_allows(project["compat"]["QUBOTools"], v"0.12.1")
+    end
+
+    return nothing
+end

--- a/test/project.jl
+++ b/test/project.jl
@@ -1,9 +1,5 @@
 function _compat_allows(compat::AbstractString, version::VersionNumber)
-    specs = split(compat, ',')
-
-    return any(specs) do spec
-        version in QUBOLib.Pkg.Types.VersionSpec(strip(spec))
-    end
+    return version in QUBOLib.Pkg.Types.semver_spec(compat)
 end
 
 function test_project_metadata()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ import QUBOTools
 import QUBOLib
 
 include("synthesis.jl")
+include("project.jl")
 include("library/path.jl")
 include("library/access.jl")
 include("readme.jl")
@@ -13,6 +14,7 @@ include("docs.jl")
 function main()
     @testset "♣ QUBOLib.jl «$(QUBOLib.__version__())» Test Suite ♣" verbose = true begin
         test_path()
+        test_project_metadata()
         test_library_access()
         test_synthesis()
         test_readme()


### PR DESCRIPTION
Summary
- Bump QUBOLib to 0.1.1 so a new release can carry the existing `QUBOTools = "0.10, 0.12"` compat.
- Add project metadata coverage for the package version and `QUBOTools v0.12.1` compatibility.
- Update build release-tag tests to derive expected data tags from the current package version.

Tests
- `julia --project=. -e 'import Pkg; Pkg.test()'` passed: 99/99 tests, with `QUBOTools v0.12.1` selected in the test environment.
- `julia --project=docs ./docs/make.jl --skip-deploy` passed. Documenter reported existing noncanonical docstring warnings.
- `make test-build` passed: 99/99 tests.
- `git diff --check` passed.
- `julia --startup-file=no -e '...'` passed: resolved `QUBOLib 0.1.1` with `QUBOTools 0.12.1` in a temporary environment.

Notes
- No documented lint, type-check, or format command was found beyond the Makefile and CI Julia checks above.
- General registry registration still needs to happen after the release commit is merged and tagged.

Refs #10
