### PR TITLE
Add TagBot release automation

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,17 @@
+name: TagBot
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1.25.7
+        with:
+          # GITHUB_TOKEN-created tags do not trigger docs.yml; add ssh if package tags should deploy docs.
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1.25.7
         with:
-          # GITHUB_TOKEN-created tags do not trigger docs.yml; add ssh if package tags should deploy docs.
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: julia-actions/setup-julia@v1
       with:
         version: '1.10'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,14 @@ jobs:
     - name: Retrieve Last Release Tag
       run: |
         cd $GITHUB_WORKSPACE
-        LAST_TAG="$(gh release view | sed -nr 's/tag:\s*(v\S*)/\1/p')"
+        LAST_TAG="$(
+          gh release list \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --limit 1000 \
+            --json tagName,publishedAt \
+            --jq '[.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-data\\+[0-9]+$"))] | sort_by(.publishedAt) | last | .tagName // empty'
+        )"
         echo "$LAST_TAG" >> ./dist/build/last.tag
         ls -la ./dist/build/
 

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
 


### PR DESCRIPTION
Summary:

- Add `.github/workflows/TagBot.yml` for registered Julia package tags/releases.
- Configure TagBot with `secrets.SSH_KEY` so package tag pushes can trigger downstream workflows such as `docs.yml`.
- Keep TagBot on `ubuntu-latest` with `issue_comment.created` and manual `workflow_dispatch`.
- Update the data deployment workflow to find the latest `v*-data+*` release explicitly, so future package GitHub releases do not become the data artifact baseline.
- Update remaining `actions/checkout@v2` workflow uses in touched release/docs maintenance workflows to `actions/checkout@v4`.

Notes:

- `SSH_KEY` exists as a repository secret.
- The data-release selector was verified against the current releases and returns `v0.1.0-data+2`, ignoring non-data package tags/releases.
- Manual TagBot dispatch was not run because the workflow must be merged before a meaningful repository dispatch test.

Tests:

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/TagBot.yml .github/workflows/deploy.yml .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/docs-cleanup.yml` - passed
- `actionlint .github/workflows/TagBot.yml .github/workflows/deploy.yml .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/docs-cleanup.yml` - passed
- `jq -nr '[{"tagName":"v0.1.0-data+1","publishedAt":"2024-10-15T22:29:49Z"},{"tagName":"v0.1.1","publishedAt":"2026-06-01T16:20:00Z"},{"tagName":"v0.1.0-data+2","publishedAt":"2026-05-31T15:41:57Z"}] | [.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-data\\+[0-9]+$"))] | sort_by(.publishedAt) | last | .tagName // empty'` - passed, returned `v0.1.0-data+2`
- `gh release list --repo JuliaQUBO/QUBOLib.jl --exclude-drafts --exclude-pre-releases --limit 1000 --json tagName,publishedAt --jq '[.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-data\\+[0-9]+$"))] | sort_by(.publishedAt) | last | .tagName // empty'` - passed, returned `v0.1.0-data+2`
- `make test-build` - passed, 99 tests
- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed, 99 tests

Closes #29.
