### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Summary

- Adds `.github/dependabot.yml` for dependency maintenance.
- Enables weekly Dependabot updates for Julia dependencies in `/` and `/docs`.
- Enables monthly Dependabot updates for GitHub Actions.
- Does not add CompatHelper, matching the ecosystem policy from JuliaQUBO/QUBO.jl#30/#31.

Notes

- Dependabot uses the default `GITHUB_TOKEN`; no repository PAT is required for this configuration.
- The docs workflow already builds pull request documentation with `docs/make.jl --skip-deploy` and deploys only outside pull request events, so Dependabot PRs should avoid the Documenter preview publish 403 path.
- `test/Project.toml` and `scripts/build/Project.toml` do not maintain their own `[compat]` bounds, so this PR does not add Dependabot entries for those directories.
- Post-creation issue updates were checked: this repository does not use `thollander/actions-comment-pull-request`, does not pin `Statistics` or other test stdlibs in `[compat]`, and should review the first Dependabot PR batch for parser/runtime compatibility changes as they appear.

Checks

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "valid YAML"'`
- `julia --project=docs ./docs/make.jl --skip-deploy`
- `julia --project=. -e 'import Pkg; Pkg.test()'`

Closes #30
