### PR TITLE
Prepare QUBOLib 0.1.2 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBOLib"
 uuid = "c2d3eca2-2309-4628-88a9-9d4a554e7c47"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"


### PR DESCRIPTION
Summary
- Bump QUBOLib to 0.1.2 for a patch release after the Dependabot/TagBot maintenance work since v0.1.1.
- This release carries the root JSON 1.6 compatibility update and the JSON-safe planted-solution metadata fix.

Tests
- `git diff --check` passed.
- `julia --project=. -e 'import Pkg; Pkg.test()'` passed: 101/101 tests.
- `make test-build` passed: 99/99 tests.
- `julia --project=docs ./docs/make.jl --skip-deploy` passed, with the existing noncanonical-docstring warnings.
- Temporary resolver/runtime check passed with QUBOLib 0.1.2, JSON v1.6.1, and QUBOTools v0.12.2.

Notes
- General registry registration and the v0.1.2 tag remain post-merge release steps.