### PR TITLE
[codex] Clean up release docs and access handling

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -14,4 +14,8 @@ jobs:
       - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1.25.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Requires a repository secret named SSH_KEY whose public key is added
+          # as a write-enabled deploy key. Without it, TagBot may need manual
+          # intervention for tags that trigger other workflows or touch workflow
+          # files.
           ssh: ${{ secrets.SSH_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## v0.1.2 - 2026-06-03
+
+- Registered QUBOLib `0.1.2` in General.
+- Added dependency maintenance automation through Dependabot.
+- Added TagBot automation for Julia package tags and releases.
+- Updated GitHub Actions dependencies.
+- Expanded compatibility for `JSON` and `QUBOTools`, including JSON-safe planted metadata for synthesized Wishart instances.
+
+## v0.1.1 - 2026-06-03
+
+- Registered QUBOLib `0.1.1` in General.
+- Prepared package metadata and tests for the registered release flow.
+
+## v0.1.0 - 2024-10-03
+
+- Initial registered package release.
+- Provided the QUBOLib SQLite/HDF5 access layer and artifact-backed benchmark library.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ### Installation
 
 ```julia
-julia> import Pkg; Pkg.add(url="https://github.com/JuliaQUBO/QUBOLib.jl")
+julia> import Pkg; Pkg.add("QUBOLib")
 
 julia> using QUBOLib
 ```
@@ -94,3 +94,8 @@ julia> QUBOLib.access() do index
            ) |> DataFrame
        end
 ```
+
+## Project maintenance
+
+- See [`CHANGELOG.md`](CHANGELOG.md) for package release notes.
+- See [`RELEASE.md`](RELEASE.md) for the package and data-artifact release checklist.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,48 @@
+# Release Checklist
+
+This repository has two release streams:
+
+- Julia package releases, tagged as `vX.Y.Z` and registered in General.
+- QUBOLib data artifact releases, tagged as `vX.Y.Z-data+N` and published by the `Deployment` workflow.
+
+## Package Release
+
+1. Open a release PR that bumps `version` in `Project.toml`.
+2. Run the package tests and documentation build.
+3. Merge the release PR after CI is green.
+4. Tag the merge commit:
+
+   ```bash
+   git tag -a vX.Y.Z -m "QUBOLib vX.Y.Z" <merge-commit>
+   git push origin vX.Y.Z
+   ```
+
+5. Trigger Registrator on the merge commit:
+
+   ```text
+   @JuliaRegistrator register
+   ```
+
+6. Confirm the General registry PR merges.
+7. Confirm TagBot creates the GitHub release, or create it manually if TagBot opens an intervention issue.
+
+## TagBot Setup
+
+TagBot uses `secrets.SSH_KEY` in `.github/workflows/TagBot.yml`. The matching
+public key must be installed as a write-enabled deploy key for this repository.
+This is needed when TagBot must create package tags that also trigger other
+workflows, such as documentation deployment.
+
+If TagBot reports manual intervention for an old registered version whose tag is
+missing, create the tag at the registered commit before creating the release.
+For the historical `v0.1.0` registration, the registered commit is
+`41087be73d756e95a2f6e8a307057af1f0c9fb0a`:
+
+```bash
+git tag -a v0.1.0 -m "QUBOLib v0.1.0" 41087be73d756e95a2f6e8a307057af1f0c9fb0a
+git push origin v0.1.0
+gh release create v0.1.0 --generate-notes --target 41087be73d756e95a2f6e8a307057af1f0c9fb0a
+```
+
+Do not run `gh release create v0.1.0` without an explicit target if the tag is
+missing; that can create the release tag at the wrong commit.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,12 @@
 
 ## Actions
 
+```@docs
+QUBOLib.clear!
+QUBOLib.build!
+QUBOLib.run!
+```
+
 ## Path Routing
 
 ```@docs
@@ -15,6 +21,7 @@ QUBOLib.root_path
 QUBOLib.dist_path
 QUBOLib.build_path
 QUBOLib.cache_path
+QUBOLib.cache_data_path
 ```
 
 ## Library Index

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -23,15 +23,16 @@ builders.
 function build! end
 
 @doc raw"""
-    run!(index::LibraryIndex, instance::Integer, optimizer)
-    run!(index::LibraryIndex, instances::Vector{U}, optimizer) where {U<:Integer}
+    run!(index::LibraryIndex, optimizer, codes::AbstractVector{U}; kws...) where {U<:Integer}
+    run!(config!::Function, index::LibraryIndex, optimizer, codes::AbstractVector{U}; kws...) where {U<:Integer}
+    run!(index::LibraryIndex, model::JuMP.Model, code::Integer; solver::Union{Symbol,Nothing}=nothing)
 
 Runs an optimizer on one or more stored instances and records returned samples
 in the library index.
 
-The optimizer is wrapped in a JuMP model, each selected instance is loaded from
-`index`, and sampler output is stored with [`add_solution!`](@ref) when the
-backend exposes a `QUBOTools.SampleSet`.
+The vector methods wrap `optimizer` in a JuMP model, each selected instance is
+loaded from `index`, and sampler output is stored with [`add_solution!`](@ref)
+when the backend exposes a `QUBOTools.SampleSet`.
 """
 function run! end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,17 +2,36 @@
 
 @doc raw"""
     clear!(source::Symbol, cache::Bool = true)
+
+Clears generated build artifacts for a source collection.
+
+When `cache` is `true`, cached source data for the collection is removed as
+well. This is intended for maintainers rebuilding the packaged benchmark
+artifact.
 """
 function clear! end
 
 @doc raw"""
     build!(source::Symbol)
+
+Builds the packaged QUBOLib artifact data for a source collection.
+
+This maintainer-facing entry point is used by the scripts under
+`scripts/build/` to populate the SQLite/HDF5 library from source-specific
+builders.
 """
 function build! end
 
 @doc raw"""
     run!(index::LibraryIndex, instance::Integer, optimizer)
     run!(index::LibraryIndex, instances::Vector{U}, optimizer) where {U<:Integer}
+
+Runs an optimizer on one or more stored instances and records returned samples
+in the library index.
+
+The optimizer is wrapped in a JuMP model, each selected instance is loaded from
+`index`, and sampler output is stored with [`add_solution!`](@ref) when the
+backend exposes a `QUBOTools.SampleSet`.
 """
 function run! end
 
@@ -28,6 +47,8 @@ function run! end
 Loads the index for an instance library.
 
 If `path` is not provided, the latest QUBOLib artifact will be used.
+Callback-style access wraps SQLite writes in a savepoint and rolls them back if
+the callback throws before the index is closed.
 
 ## Example
 

--- a/src/library/access.jl
+++ b/src/library/access.jl
@@ -48,26 +48,23 @@ function access(callback::Any; path::AbstractString = pwd(), clear::Bool = false
     try
         db = database(index)
 
-        DBInterface.execute(db, "SAVEPOINT qubolib_access;")
+        _begin_access_savepoint!(db)
 
         try
             result = callback(index)
 
             if isopen(db)
-                DBInterface.execute(db, "RELEASE SAVEPOINT qubolib_access;")
+                _release_access_savepoint!(db)
             end
 
             return result
-        catch err
+        catch
             if isopen(db)
-                DBInterface.execute(db, "ROLLBACK TO SAVEPOINT qubolib_access;")
-                DBInterface.execute(db, "RELEASE SAVEPOINT qubolib_access;")
+                _rollback_access_savepoint!(db)
             end
 
-            rethrow(err)
+            rethrow()
         end
-    catch err
-        rethrow(err)
     finally
         close(index)
     end

--- a/src/library/access.jl
+++ b/src/library/access.jl
@@ -46,13 +46,29 @@ function access(callback::Any; path::AbstractString = pwd(), clear::Bool = false
     @assert isopen(index)
 
     try
-        # TODO: Start transaction here
-        return callback(index)
+        db = database(index)
+
+        DBInterface.execute(db, "SAVEPOINT qubolib_access;")
+
+        try
+            result = callback(index)
+
+            if isopen(db)
+                DBInterface.execute(db, "RELEASE SAVEPOINT qubolib_access;")
+            end
+
+            return result
+        catch err
+            if isopen(db)
+                DBInterface.execute(db, "ROLLBACK TO SAVEPOINT qubolib_access;")
+                DBInterface.execute(db, "RELEASE SAVEPOINT qubolib_access;")
+            end
+
+            rethrow(err)
+        end
     catch err
-        # TODO: Implement some transaction rollback functionality!
         rethrow(err)
     finally
-        # TODO: Close transaction here
         close(index)
     end
 end

--- a/src/library/index.jl
+++ b/src/library/index.jl
@@ -14,15 +14,54 @@ struct LibraryIndex
     end
 end
 
+const _ACCESS_SAVEPOINT_NAME = "qubolib_access"
+const _ACCESS_SAVEPOINTS = IdDict{SQLite.DB,Bool}()
+
+function _begin_access_savepoint!(db::SQLite.DB)
+    DBInterface.execute(db, "SAVEPOINT $(_ACCESS_SAVEPOINT_NAME);")
+    _ACCESS_SAVEPOINTS[db] = true
+
+    return nothing
+end
+
+function _release_access_savepoint!(db::SQLite.DB)
+    if get(_ACCESS_SAVEPOINTS, db, false)
+        try
+            DBInterface.execute(db, "RELEASE SAVEPOINT $(_ACCESS_SAVEPOINT_NAME);")
+        finally
+            delete!(_ACCESS_SAVEPOINTS, db)
+        end
+    end
+
+    return nothing
+end
+
+function _rollback_access_savepoint!(db::SQLite.DB)
+    if get(_ACCESS_SAVEPOINTS, db, false)
+        try
+            DBInterface.execute(db, "ROLLBACK TO SAVEPOINT $(_ACCESS_SAVEPOINT_NAME);")
+        finally
+            try
+                DBInterface.execute(db, "RELEASE SAVEPOINT $(_ACCESS_SAVEPOINT_NAME);")
+            finally
+                delete!(_ACCESS_SAVEPOINTS, db)
+            end
+        end
+    end
+
+    return nothing
+end
+
 function Base.isopen(index::LibraryIndex)
     return isopen(index.db) && isopen(index.h5)
 end
 
 function Base.close(index::LibraryIndex)
     if isopen(index.db)
+        _release_access_savepoint!(index.db)
         close(index.db)
     end
-    
+
     if isopen(index.h5)
         close(index.h5)
     end

--- a/src/library/path.jl
+++ b/src/library/path.jl
@@ -89,9 +89,13 @@ end
 cache_path(index::LibraryIndex, paths...) = cache_path(root_path(index), paths...)
 
 @doc raw"""
-    cache_data_path(path::AbstractString, paths...)
+    cache_data_path(path::AbstractString = root_path(), paths...)
+    cache_data_path(index::LibraryIndex, paths...)
 
-Returns the absolute path to the data cache folder, given a reference _root path_ `path`.
+Returns the absolute path to a source-data cache folder.
+
+For a root path, the returned path is nested under `dist/cache`. For an open
+[`LibraryIndex`](@ref), the root path is inferred from the index location.
 """
 function cache_data_path(path::AbstractString = root_path(), paths...)::String
     return joinpath(cache_path(path, paths...), "data")

--- a/test/library/access.jl
+++ b/test/library/access.jl
@@ -215,6 +215,32 @@ function test_library_access()
                 @test isempty(collections)
             end
         end
+
+        mktempdir() do path
+            QUBOLib.access(; path, clear = true) do index
+                QUBOLib.add_collection!(
+                    index,
+                    "closed-savepoint",
+                    Dict{String,Any}(
+                        "name" => "Closed Savepoint",
+                        "author" => ["QUBOLib"],
+                    ),
+                )
+
+                close(index)
+            end
+
+            QUBOLib.access(; path) do index
+                collections =
+                    QUBOLib.DBInterface.execute(
+                        QUBOLib.database(index),
+                        "SELECT collection FROM Collections WHERE collection = ?;",
+                        ("closed-savepoint",),
+                    ) |> QUBOLib.DataFrame
+
+                @test size(collections, 1) == 1
+            end
+        end
     end
 
     @testset "Best solution sense" begin

--- a/test/library/access.jl
+++ b/test/library/access.jl
@@ -189,6 +189,34 @@ function test_library_access()
         end
     end
 
+    @testset "Callback transactions" begin
+        mktempdir() do path
+            @test_throws ErrorException QUBOLib.access(; path, clear = true) do index
+                QUBOLib.add_collection!(
+                    index,
+                    "rolled-back",
+                    Dict{String,Any}(
+                        "name" => "Rolled Back",
+                        "author" => ["QUBOLib"],
+                    ),
+                )
+
+                error("abort transaction")
+            end
+
+            QUBOLib.access(; path) do index
+                collections =
+                    QUBOLib.DBInterface.execute(
+                        QUBOLib.database(index),
+                        "SELECT collection FROM Collections WHERE collection = ?;",
+                        ("rolled-back",),
+                    ) |> QUBOLib.DataFrame
+
+                @test isempty(collections)
+            end
+        end
+    end
+
     @testset "Best solution sense" begin
         mktempdir() do path
             model = QUBOTools.Model(


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` and `RELEASE.md` with the package/data release flow and TagBot recovery notes.
- Update README installation to use the registered package name and link the maintenance docs.
- Include the public action/path docstrings in the API page to remove Documenter canonical-doc warnings.
- Wrap callback-style `QUBOLib.access` in a SQLite savepoint and add rollback coverage.
- Document the required `SSH_KEY` deploy-key setup beside the TagBot workflow input.

## Notes

TagBot issue #39 still requires a repository setting change: the private key must be stored in `secrets.SSH_KEY`, and the matching public key must be installed as a write-enabled deploy key. This PR documents the required setup and the safe manual recovery for historical `v0.1.0`, but cannot add repository secrets or deploy keys.

## Validation

- `git diff --check`
- `julia --project=. -e 'import Pkg; Pkg.test()'`
- `julia --project=docs ./docs/make.jl --skip-deploy`
- `make test-build`
