### PR TITLE
release: prepare QUBOLib 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.3 - 2026-06-03
+
+- Added package and data release maintenance documentation.
+- Documented the TagBot SSH deploy-key setup and safe manual recovery path for historical releases.
+- Updated README installation and maintenance links for the registered package.
+- Added public action/path API entries to the generated documentation.
+- Wrapped callback-style `QUBOLib.access` calls in a SQLite savepoint so callback errors roll back transient database changes.
+
 ## v0.1.2 - 2026-06-03
 
 - Registered QUBOLib `0.1.2` in General.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBOLib"
 uuid = "c2d3eca2-2309-4628-88a9-9d4a554e7c47"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"


### PR DESCRIPTION
## Summary

- Bump `Project.toml` to `0.1.3`.
- Add the `v0.1.3` changelog entry for the merged release-docs and access-handling cleanup.

## Validation

- `git diff --check`
- `julia --project=. -e 'import Pkg; Pkg.test()'`
- `julia --project=docs ./docs/make.jl --skip-deploy`
- `make test-build`