### PR TITLE
Benchmark julia-actions/cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
     #   - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
Summary:
- Adds `julia-actions/cache@v3` after `julia-actions/setup-julia@v3` and before `julia-actions/julia-buildpkg@v1` in the CI matrix.
- Keeps the change limited to `.github/workflows/ci.yml`; no package code changes.

Local validation:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'` -> `YAML OK`
- Julia package tests were not run locally because this is a CI workflow-only benchmark change.

CI benchmark:
- First CI attempt, cache population run, success:
- Julia 1.10 Ubuntu: total `2m18s`; setup-julia `5s`; cache `0s`; buildpkg `15s`; runtest `1m50s`.
- Julia 1 Ubuntu: total `4m31s`; setup-julia `9s`; cache `1s`; buildpkg `14s`; runtest `3m52s`.
- Julia 1.10 Windows: total `4m05s`; setup-julia `18s`; cache `1s`; buildpkg `38s`; runtest `2m42s`.
- Julia 1 Windows: total `5m53s`; setup-julia `12s`; cache `4s`; buildpkg `35s`; runtest `4m37s`.

- Warm-cache CI rerun, success:
- Julia 1.10 Ubuntu: total `1m28s`; setup-julia `5s`; cache `6s`; buildpkg `11s`; runtest `50s`.
- Julia 1 Ubuntu: total `1m27s`; setup-julia `8s`; cache `7s`; buildpkg `8s`; runtest `49s`.
- Julia 1.10 Windows: total `2m03s`; setup-julia `9s`; cache `14s`; buildpkg `16s`; runtest `1m00s`.
- Julia 1 Windows: total `1m54s`; setup-julia `16s`; cache `13s`; buildpkg `11s`; runtest `52s`.

Cache evidence:
- The warm-cache rerun restored caches in all four matrix jobs from `run_attempt=1`.
- The warm-cache rerun saved caches in all four matrix jobs with `run_attempt=2`.

Conclusion:
- Issue baseline slowest job: `5m48s` for Julia 1 Windows.
- Warm-cache slowest job: `2m03s` for Julia 1.10 Windows.
- Critical-path improvement versus the issue baseline is about `3m45s`, or roughly `65%`, so this clears the material-improvement threshold in #42.

Closes #42
