### PR TITLE
Preserve QOBLIB source provenance

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,7 +67,9 @@ missing; that can create the release tag at the wrong commit.
 
 - `SolutionRecords` includes nullable `source_objective`, `dual_bound`, and
   `source_feasible` columns for source-model evaluation. Existing artifacts are
-  migrated in place when opened through `QUBOLib.access`.
+  migrated in place when opened through `QUBOLib.access`. QOBLIB submission
+  optimality bounds are written to `dual_bound`; `objective_bound` is retained
+  with the same value for backward compatibility.
 - Instances may include an optional HDF5 source group at
   `/instances/{id}/source`. LP-backed source groups store `content`, an
   `encoding` JSON blob, a `source_format = "lp"` attribute, and source

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,4 +70,8 @@ missing; that can create the release tag at the wrong commit.
   migrated in place when opened through `QUBOLib.access`.
 - Instances may include an optional HDF5 source group at
   `/instances/{id}/source`. LP-backed source groups store `content`, an
-  `encoding` JSON blob, and a `source_format = "lp"` attribute.
+  `encoding` JSON blob, a `source_format = "lp"` attribute, and source
+  provenance attributes such as upstream repository, commit, path, URL,
+  SHA-256 hash, byte size, and storage policy. QOBLIB LP source text is stored
+  only when the blob is at most 1,000,000 bytes; larger blobs keep provenance
+  and hash metadata without a `content` dataset.

--- a/docs/src/manual/3-qoblib.md
+++ b/docs/src/manual/3-qoblib.md
@@ -30,3 +30,18 @@ If QOBLIB later publishes official QS/QUBO artifacts for any class, QUBOLib can
 add that class to the canonical importer and validate it against upstream
 metrics. LP/MIP-to-QUBO reformulation variants belong in a separate generated
 collection with explicit naming and provenance.
+
+## Source Formulation Storage
+
+When a canonical QOBLIB QS/QUBO artifact has a matching authoritative source
+model, QUBOLib stores source provenance under `/instances/{id}/source` in the
+HDF5 archive. The source group records `source_format`, upstream repository,
+commit, path, URL, hash algorithm, SHA-256 content hash, byte size, and the
+source-text storage decision. If the source encoding is known and trustworthy,
+the group also stores the encoding JSON used by `QUBOLib.project_solution` and
+`QUBOLib.evaluate_source`.
+
+Source LP text is stored only when the blob is at most 1,000,000 bytes. Larger
+source files keep URL, path, size, and SHA-256 provenance in the artifact while
+omitting the `content` dataset. This keeps the data artifact bounded without
+losing enough provenance to retrieve and verify the upstream source manually.

--- a/docs/src/manual/3-qoblib.md
+++ b/docs/src/manual/3-qoblib.md
@@ -45,3 +45,7 @@ Source LP text is stored only when the blob is at most 1,000,000 bytes. Larger
 source files keep URL, path, size, and SHA-256 provenance in the artifact while
 omitting the `content` dataset. This keeps the data artifact bounded without
 losing enough provenance to retrieve and verify the upstream source manually.
+
+When QOBLIB submission metadata provides an upstream optimality bound, QUBOLib
+stores it in `SolutionRecords.dual_bound`. The legacy `objective_bound` column
+keeps the same value for backward compatibility with existing consumers.

--- a/scripts/build/build.jl
+++ b/scripts/build/build.jl
@@ -1,6 +1,7 @@
 import Pkg
 import Tar
 import Downloads
+import SHA
 import TOML
 
 import QUBOLib

--- a/scripts/build/runtests.jl
+++ b/scripts/build/runtests.jl
@@ -435,6 +435,32 @@ function test_qoblib_build_fixture()
                 expected_incumbents = 1,
                 nested = false,
             ),
+            (
+                code = "constrainedfixture",
+                problem_class = "Constrained Source Fixture",
+                formulation = "binary_quadratic_with_source",
+                path = "11-constrained/models/binary_quadratic/qs_files",
+                source_model_path = "11-constrained/models/integer_linear/lp_files",
+                source_model_format = "lp",
+                source_encoding = Dict{String,Any}(
+                    "variables" => Dict{String,Any}(
+                        "x" => Dict{String,Any}(
+                            "terms" => [Dict{String,Any}("index" => 1)],
+                        ),
+                        "y" => Dict{String,Any}(
+                            "terms" => [Dict{String,Any}("index" => 2)],
+                        ),
+                        "z" => Dict{String,Any}(
+                            "terms" => [Dict{String,Any}("index" => 3)],
+                        ),
+                    ),
+                ),
+                solution_path = "11-constrained/solutions",
+                solution_format = :bit_tokens,
+                expected_count = 1,
+                expected_incumbents = 1,
+                nested = false,
+            ),
         )
 
         mktempdir() do root
@@ -507,6 +533,28 @@ function test_qoblib_build_fixture()
                 "# Objective value = 2\n1\n3\n",
             )
 
+            _write_qoblib_fixture_group(root, groups[5], ["constrained.qs"])
+            source_model_path = mkpath(joinpath(root, groups[5].source_model_path))
+            source_lp_path = joinpath(source_model_path, "constrained.lp")
+            write(
+                source_lp_path,
+                """
+                Minimize
+                 obj: x + 2 y - 4 z
+                Subject To
+                 c1: x + y <= 1
+                Bounds
+                 0 <= x <= 1
+                 0 <= y <= 1
+                 0 <= z <= 1
+                Binary
+                 x y z
+                End
+                """,
+            )
+            solution_path = _write_qoblib_solution_dir(root, groups[5])
+            write(joinpath(solution_path, "constrained.opt.sol"), "1 0 0\n")
+
             mktempdir() do path
                 QUBOLib.access(; path, clear = true) do index
                     build_qoblib!(index; source_path = root, groups = groups)
@@ -528,7 +576,8 @@ function test_qoblib_build_fixture()
                             QUBOLib.database(index),
                             """
                             SELECT i.instance, i.name, r.submission, r.bitstring, r.qubo_value,
-                                   r.source_value, r.proven_optimal,
+                                   r.source_value, r.source_objective, r.dual_bound,
+                                   r.source_feasible, r.proven_optimal,
                                    r.feasibility_status, r.validation_status,
                                    r.incumbent_candidate, r.source_path, r.solution,
                                    r.metadata
@@ -560,15 +609,15 @@ function test_qoblib_build_fixture()
                             """,
                         ) |> QUBOLib.DataFrame
 
-                    @test count == 5
+                    @test count == 6
                     @test Set(data[!, :source_name]) == Set(["QOBLIB"])
                     @test Set(data[!, :problem_class]) ==
                           Set(getfield.(groups, :problem_class))
                     @test Set(data[!, :formulation]) == Set(getfield.(groups, :formulation))
                     @test all(endswith(path, ".qs") for path in data[!, :source_path])
-                    @test size(records, 1) == 8
+                    @test size(records, 1) == 9
                     @test size(submissions, 1) == 3
-                    @test size(best, 1) == 4
+                    @test size(best, 1) == 5
 
                     missing = only(
                         eachrow(
@@ -694,6 +743,35 @@ function test_qoblib_build_fixture()
                     @test Bool(independent[:proven_optimal])
                     @test QUBOLib.JSON.parse(independent[:metadata])["source_value_agrees"] ==
                           true
+
+                    constrained = only(
+                        eachrow(filter(row -> row[:name] == "constrained.qs", records)),
+                    )
+                    source_group =
+                        QUBOLib.archive(index)["instances"][string(constrained[:instance])]["source"]
+                    source_attrs = QUBOLib.HDF5.attrs(source_group)
+                    source_evaluation = QUBOLib.evaluate_source(
+                        index,
+                        constrained[:instance],
+                        constrained[:bitstring],
+                    )
+
+                    @test ismissing(constrained[:source_value])
+                    @test constrained[:source_objective] ≈ 1.0
+                    @test ismissing(constrained[:dual_bound])
+                    @test Bool(constrained[:source_feasible])
+                    @test source_attrs["source_format"] == "lp"
+                    @test source_attrs["source_repository"] == QOBLIB_REPOSITORY
+                    @test source_attrs["source_commit"] == QOBLIB_SOURCE_COMMIT
+                    @test source_attrs["source_path"] ==
+                          "11-constrained/models/integer_linear/lp_files/constrained.lp"
+                    @test source_attrs["source_hash_algorithm"] == "sha256"
+                    @test source_attrs["source_sha256"] ==
+                          bytes2hex(SHA.sha256(read(source_lp_path)))
+                    @test source_attrs["source_text_storage"] == "stored"
+                    @test read(source_group["content"]) == read(source_lp_path, String)
+                    @test source_evaluation.objective ≈ constrained[:source_objective]
+                    @test source_evaluation.feasible
 
                     for row in eachrow(best)
                         model = QUBOLib.load_instance(index, row[:instance])

--- a/scripts/build/runtests.jl
+++ b/scripts/build/runtests.jl
@@ -461,6 +461,33 @@ function test_qoblib_build_fixture()
                 expected_incumbents = 1,
                 nested = false,
             ),
+            (
+                code = "limitedsourcefixture",
+                problem_class = "Limited Source Fixture",
+                formulation = "binary_quadratic_with_source",
+                path = "12-limited/models/binary_quadratic/qs_files",
+                source_model_path = "12-limited/models/integer_linear/lp_files",
+                source_model_format = "lp",
+                source_text_max_bytes = 16,
+                source_encoding = Dict{String,Any}(
+                    "variables" => Dict{String,Any}(
+                        "x" => Dict{String,Any}(
+                            "terms" => [Dict{String,Any}("index" => 1)],
+                        ),
+                        "y" => Dict{String,Any}(
+                            "terms" => [Dict{String,Any}("index" => 2)],
+                        ),
+                        "z" => Dict{String,Any}(
+                            "terms" => [Dict{String,Any}("index" => 3)],
+                        ),
+                    ),
+                ),
+                solution_path = "12-limited/solutions",
+                solution_format = :bit_tokens,
+                expected_count = 1,
+                expected_incumbents = 1,
+                nested = false,
+            ),
         )
 
         mktempdir() do root
@@ -555,6 +582,28 @@ function test_qoblib_build_fixture()
             solution_path = _write_qoblib_solution_dir(root, groups[5])
             write(joinpath(solution_path, "constrained.opt.sol"), "1 0 0\n")
 
+            _write_qoblib_fixture_group(root, groups[6], ["limited.qs"])
+            limited_source_model_path = mkpath(joinpath(root, groups[6].source_model_path))
+            limited_source_lp_path = joinpath(limited_source_model_path, "limited.lp")
+            write(
+                limited_source_lp_path,
+                """
+                Minimize
+                 obj: x + 2 y - 4 z
+                Subject To
+                 c1: x + y <= 1
+                Bounds
+                 0 <= x <= 1
+                 0 <= y <= 1
+                 0 <= z <= 1
+                Binary
+                 x y z
+                End
+                """,
+            )
+            solution_path = _write_qoblib_solution_dir(root, groups[6])
+            write(joinpath(solution_path, "limited.opt.sol"), "1 0 0\n")
+
             mktempdir() do path
                 QUBOLib.access(; path, clear = true) do index
                     build_qoblib!(index; source_path = root, groups = groups)
@@ -609,15 +658,15 @@ function test_qoblib_build_fixture()
                             """,
                         ) |> QUBOLib.DataFrame
 
-                    @test count == 6
+                    @test count == 7
                     @test Set(data[!, :source_name]) == Set(["QOBLIB"])
                     @test Set(data[!, :problem_class]) ==
                           Set(getfield.(groups, :problem_class))
                     @test Set(data[!, :formulation]) == Set(getfield.(groups, :formulation))
                     @test all(endswith(path, ".qs") for path in data[!, :source_path])
-                    @test size(records, 1) == 9
+                    @test size(records, 1) == 10
                     @test size(submissions, 1) == 3
-                    @test size(best, 1) == 5
+                    @test size(best, 1) == 6
 
                     missing = only(
                         eachrow(
@@ -773,6 +822,28 @@ function test_qoblib_build_fixture()
                     @test source_evaluation.objective ≈ constrained[:source_objective]
                     @test source_evaluation.feasible
 
+                    limited = only(
+                        eachrow(filter(row -> row[:name] == "limited.qs", records)),
+                    )
+                    limited_source_group =
+                        QUBOLib.archive(index)["instances"][string(limited[:instance])]["source"]
+                    limited_source_attrs = QUBOLib.HDF5.attrs(limited_source_group)
+
+                    @test ismissing(limited[:source_objective])
+                    @test ismissing(limited[:source_feasible])
+                    @test limited_source_attrs["source_format"] == "lp"
+                    @test limited_source_attrs["source_path"] ==
+                          "12-limited/models/integer_linear/lp_files/limited.lp"
+                    @test limited_source_attrs["source_sha256"] ==
+                          bytes2hex(SHA.sha256(read(limited_source_lp_path)))
+                    @test limited_source_attrs["source_size_bytes"] ==
+                          sizeof(read(limited_source_lp_path, String))
+                    @test limited_source_attrs["source_text_max_bytes"] == 16
+                    @test limited_source_attrs["source_text_storage"] ==
+                          "omitted_size_limit"
+                    @test !haskey(limited_source_group, "content")
+                    @test haskey(limited_source_group, "encoding")
+
                     for row in eachrow(best)
                         model = QUBOLib.load_instance(index, row[:instance])
                         state = QUBOLib._bitstring_state(row[:bitstring])
@@ -886,6 +957,46 @@ function test_qoblib_submission_failure_handling()
                         summary,
                     )
                 end
+            end
+        end
+
+        mktempdir() do path
+            QUBOLib.access(; path, clear = true) do index
+                instance = QUBOLib.add_instance!(
+                    index,
+                    model;
+                    name = "bad-source.qs",
+                    source_format = "lp",
+                    source_text = """
+                    Minimize
+                     obj: x + y + z
+                    Subject To
+                     c1: x + y <= 1
+                    Bounds
+                     0 <= x <= 1
+                     0 <= y <= 1
+                     0 <= z <= 1
+                    Binary
+                     x y z
+                    End
+                    """,
+                    source_encoding = Dict{String,Any}(
+                        "variables" => Dict{String,Any}(
+                            "unmapped" => Dict{String,Any}(
+                                "terms" => [Dict{String,Any}("index" => 1)],
+                            ),
+                        ),
+                    ),
+                )
+                evaluator = _qoblib_source_evaluator(index, instance; context = "bad-source")
+                evaluation = _qoblib_source_evaluation(
+                    evaluator,
+                    [1, 0, 0];
+                    context = "bad-source",
+                )
+
+                @test ismissing(evaluation.source_objective)
+                @test ismissing(evaluation.source_feasible)
             end
         end
     end

--- a/scripts/build/sources/qoblib.jl
+++ b/scripts/build/sources/qoblib.jl
@@ -985,21 +985,101 @@ function _qoblib_instance_source(
     )
 end
 
-function _qoblib_source_evaluation(index::QUBOLib.LibraryIndex, instance::Integer, state)
+function _qoblib_source_evaluator(
+    index::QUBOLib.LibraryIndex,
+    instance::Integer;
+    context::AbstractString = string(instance),
+)
     group = QUBOLib.archive(index)["instances"][string(instance)]
 
     if !haskey(group, "source") ||
        !haskey(group["source"], "content") ||
        !haskey(group["source"], "encoding")
+        return nothing
+    end
+
+    try
+        source_group = group["source"]
+        encoding = QUBOLib._source_encoding(source_group)
+
+        return (
+            instance = instance,
+            dimension = QUBOLib._instance_dimension(index, instance),
+            model = QUBOLib.source_model(index, instance),
+            variables = QUBOLib._encoding_variables(encoding),
+            index_base = QUBOLib._encoding_index_base(encoding),
+        )
+    catch err
+        @warn "[qoblib] Source evaluator unavailable" context error = sprint(showerror, err)
+
+        return nothing
+    end
+end
+
+function _qoblib_project_source(evaluator, state)
+    if length(state) != evaluator.dimension
+        error(
+            "Source state length mismatch for instance '$(evaluator.instance)': " *
+            "expected $(evaluator.dimension), got $(length(state))",
+        )
+    end
+
+    binary_state = Float64.(state)
+    assignment = Dict{String,Float64}()
+
+    for (name, spec) in pairs(evaluator.variables)
+        key = String(name)
+
+        if key in ("index_base", "metadata")
+            continue
+        end
+
+        assignment[key] = QUBOLib._project_variable(
+            spec,
+            binary_state,
+            evaluator.index_base,
+        )
+    end
+
+    return assignment
+end
+
+function _qoblib_source_evaluation(
+    evaluator,
+    state;
+    context::AbstractString,
+    atol::Real = 1e-8,
+)
+    if isnothing(evaluator)
         return (source_objective = missing, source_feasible = missing)
     end
 
-    evaluated = QUBOLib.evaluate_source(index, instance, state)
+    try
+        assignment = _qoblib_project_source(evaluator, state)
+        variable_value = variable -> QUBOLib._source_variable_value(assignment, variable)
+        objective = QUBOLib.JuMP.value(
+            variable_value,
+            QUBOLib.JuMP.objective_function(evaluator.model),
+        )
 
-    return (
-        source_objective = Float64(evaluated.objective),
-        source_feasible = evaluated.feasible,
-    )
+        for (F, S) in QUBOLib.JuMP.list_of_constraint_types(evaluator.model)
+            for constraint in QUBOLib.JuMP.all_constraints(evaluator.model, F, S)
+                object = QUBOLib.JuMP.constraint_object(constraint)
+                value = QUBOLib.JuMP.value(variable_value, object.func)
+                violation = QUBOLib._constraint_violation(value, object.set; atol)
+
+                if violation > atol
+                    return (source_objective = Float64(objective), source_feasible = false)
+                end
+            end
+        end
+
+        return (source_objective = Float64(objective), source_feasible = true)
+    catch err
+        @warn "[qoblib] Source evaluation unavailable" context error = sprint(showerror, err)
+
+        return (source_objective = missing, source_feasible = missing)
+    end
 end
 
 function _qoblib_clean_csv_cell(value::AbstractString)
@@ -1410,6 +1490,7 @@ function _add_qoblib_submission!(
     root_path::AbstractString,
     group,
     summary,
+    source_evaluator = nothing,
 )
     row = summary.row
     summary_path = summary.path
@@ -1493,7 +1574,11 @@ function _add_qoblib_submission!(
 
         record_source_value = ismissing(source_value) ? solution.source_value : source_value
         qubo_value = QUBOTools.value(model, solution.state)
-        source_evaluation = _qoblib_source_evaluation(index, instance, solution.state)
+        source_evaluation = _qoblib_source_evaluation(
+            source_evaluator,
+            solution.state;
+            context = solution_source_path,
+        )
         _qoblib_tag_source_value_agreement!(
             solution_metadata,
             qubo_value,
@@ -1542,6 +1627,7 @@ function _add_qoblib_submissions!(
     group,
     model_path::AbstractString,
     submission_index::Dict{String,Vector{Any}},
+    source_evaluator = nothing,
 )
     key = _qoblib_solution_key(group, model_path)
 
@@ -1557,6 +1643,7 @@ function _add_qoblib_submissions!(
             root_path,
             group,
             summary,
+            source_evaluator,
         )
     end
 end
@@ -1636,6 +1723,7 @@ function _add_qoblib_incumbent!(
     group,
     model_path::AbstractString,
     solution_index::Dict{String,Any},
+    source_evaluator = nothing,
 )
     if !hasproperty(group, :solution_path)
         return :skipped
@@ -1667,7 +1755,11 @@ function _add_qoblib_incumbent!(
     end
 
     qubo_value = QUBOTools.value(model, solution.state)
-    source_evaluation = _qoblib_source_evaluation(index, instance, solution.state)
+    source_evaluation = _qoblib_source_evaluation(
+        source_evaluator,
+        solution.state;
+        context = _qoblib_source_path(root_path, info),
+    )
     metadata = _qoblib_incumbent_metadata(root_path, group, info; source_value)
     _qoblib_tag_source_value_agreement!(
         metadata,
@@ -1795,6 +1887,12 @@ function build_qoblib!(
                 metadata          = metadata,
             )
 
+            source_evaluator = _qoblib_source_evaluator(
+                index,
+                instance;
+                context = metadata["source_path"],
+            )
+
             incumbent_status = _add_qoblib_incumbent!(
                 index,
                 instance,
@@ -1803,6 +1901,7 @@ function build_qoblib!(
                 group,
                 model_path,
                 solution_index,
+                source_evaluator,
             )
 
             if incumbent_status == :imported
@@ -1821,6 +1920,7 @@ function build_qoblib!(
                 group,
                 model_path,
                 submission_index,
+                source_evaluator,
             )
 
             count += 1

--- a/scripts/build/sources/qoblib.jl
+++ b/scripts/build/sources/qoblib.jl
@@ -4,6 +4,7 @@ const QOBLIB_COLLECTION = "qoblib"
 const QOBLIB_REPOSITORY = "ZIB-AOPT/QOBLIB"
 const QOBLIB_SOURCE_COMMIT = "80e45c176fc6281e5316451f02296482934785fa"
 const QOBLIB_ARCHIVE_URL = "https://github.com/$(QOBLIB_REPOSITORY)/archive/$(QOBLIB_SOURCE_COMMIT).zip"
+const QOBLIB_SOURCE_TEXT_MAX_BYTES = 1_000_000
 
 const QOBLIB_GROUPS = (
     (
@@ -848,6 +849,159 @@ function _qoblib_source_path(root_path::AbstractString, path::AbstractString)
     return replace(relpath(path, root_path), '\\' => '/')
 end
 
+function _qoblib_group_source_format(group)
+    if hasproperty(group, :source_model_format)
+        return lowercase(String(group.source_model_format))
+    else
+        return "lp"
+    end
+end
+
+function _qoblib_group_source_roots(root_path::AbstractString, group)
+    paths = if hasproperty(group, :source_model_path)
+        [String(group.source_model_path)]
+    elseif hasproperty(group, :source_model_paths)
+        String.(group.source_model_paths)
+    else
+        String[]
+    end
+
+    return [joinpath(root_path, path) for path in paths]
+end
+
+function _qoblib_model_relative_stem(
+    root_path::AbstractString,
+    group,
+    model_path::AbstractString,
+)
+    stem = replace(relpath(model_path, joinpath(root_path, group.path)), '\\' => '/')
+
+    if endswith(stem, ".xz")
+        stem = first(splitext(stem))
+    end
+
+    if endswith(stem, ".qs")
+        stem = first(splitext(stem))
+    end
+
+    return stem
+end
+
+function _qoblib_source_model_path(
+    root_path::AbstractString,
+    group,
+    model_path::AbstractString,
+)
+    roots = _qoblib_group_source_roots(root_path, group)
+
+    if isempty(roots)
+        return nothing
+    end
+
+    source_format = _qoblib_group_source_format(group)
+    rel_stem = _qoblib_model_relative_stem(root_path, group, model_path)
+    suffixes = source_format == "lp" ? ("lp", "LP") : (source_format,)
+    candidates = String[]
+
+    for root in roots
+        for suffix in suffixes
+            push!(candidates, joinpath(root, "$(rel_stem).$(suffix)"))
+            push!(candidates, joinpath(root, "$(basename(rel_stem)).$(suffix)"))
+        end
+    end
+
+    for path in unique(candidates)
+        isfile(path) && return path
+    end
+
+    if hasproperty(group, :source_model_required) && group.source_model_required
+        error("[qoblib] Missing source model for '$model_path'")
+    else
+        return nothing
+    end
+end
+
+function _qoblib_source_text_max_bytes(group)
+    if hasproperty(group, :source_text_max_bytes)
+        return Int(group.source_text_max_bytes)
+    else
+        return QOBLIB_SOURCE_TEXT_MAX_BYTES
+    end
+end
+
+function _qoblib_source_encoding(root_path::AbstractString, group, model_path::AbstractString)
+    if !hasproperty(group, :source_encoding)
+        return nothing
+    end
+
+    encoding = group.source_encoding
+
+    if encoding isa Function
+        return encoding(root_path, group, model_path)
+    else
+        return encoding
+    end
+end
+
+function _qoblib_instance_source(
+    root_path::AbstractString,
+    group,
+    model_path::AbstractString,
+)
+    path = _qoblib_source_model_path(root_path, group, model_path)
+
+    if isnothing(path)
+        return (
+            source_format = nothing,
+            source_text = nothing,
+            source_encoding = nothing,
+            source_metadata = nothing,
+        )
+    end
+
+    source_bytes = read(path)
+    source_format = _qoblib_group_source_format(group)
+    limit = _qoblib_source_text_max_bytes(group)
+    store_text = length(source_bytes) <= limit
+    source_path = _qoblib_source_path(root_path, path)
+    metadata = Dict{String,Any}(
+        "source_kind"           => "source_model",
+        "source_repository"     => QOBLIB_REPOSITORY,
+        "source_commit"         => QOBLIB_SOURCE_COMMIT,
+        "source_path"           => source_path,
+        "source_url"            => _qoblib_source_url(root_path, path),
+        "source_hash_algorithm" => "sha256",
+        "source_sha256"         => bytes2hex(SHA.sha256(source_bytes)),
+        "source_size_bytes"     => length(source_bytes),
+        "source_text_max_bytes" => limit,
+        "source_text_storage"   => store_text ? "stored" : "omitted_size_limit",
+    )
+
+    return (
+        source_format = source_format,
+        source_text = store_text ? String(source_bytes) : nothing,
+        source_encoding = _qoblib_source_encoding(root_path, group, model_path),
+        source_metadata = metadata,
+    )
+end
+
+function _qoblib_source_evaluation(index::QUBOLib.LibraryIndex, instance::Integer, state)
+    group = QUBOLib.archive(index)["instances"][string(instance)]
+
+    if !haskey(group, "source") ||
+       !haskey(group["source"], "content") ||
+       !haskey(group["source"], "encoding")
+        return (source_objective = missing, source_feasible = missing)
+    end
+
+    evaluated = QUBOLib.evaluate_source(index, instance, state)
+
+    return (
+        source_objective = Float64(evaluated.objective),
+        source_feasible = evaluated.feasible,
+    )
+end
+
 function _qoblib_clean_csv_cell(value::AbstractString)
     return replace(strip(value), Char(0xfeff) => "")
 end
@@ -1201,6 +1355,7 @@ function _qoblib_add_unavailable_submission_record!(
         submission,
         source_value,
         objective_bound,
+        dual_bound = objective_bound,
         proven_optimal,
         feasibility_status = feasibility_status == "feasible" ? "unavailable" : feasibility_status,
         validation_status = "unavailable",
@@ -1236,6 +1391,7 @@ function _qoblib_add_unmapped_submission_record!(
         submission,
         source_value,
         objective_bound,
+        dual_bound = objective_bound,
         proven_optimal,
         feasibility_status = "unmapped",
         validation_status = "unmapped",
@@ -1337,6 +1493,7 @@ function _add_qoblib_submission!(
 
         record_source_value = ismissing(source_value) ? solution.source_value : source_value
         qubo_value = QUBOTools.value(model, solution.state)
+        source_evaluation = _qoblib_source_evaluation(index, instance, solution.state)
         _qoblib_tag_source_value_agreement!(
             solution_metadata,
             qubo_value,
@@ -1360,7 +1517,10 @@ function _add_qoblib_submission!(
             submission,
             qubo_value,
             source_value = record_source_value,
+            source_objective = source_evaluation.source_objective,
             objective_bound,
+            dual_bound = objective_bound,
+            source_feasible = source_evaluation.source_feasible,
             proven_optimal,
             feasibility_status,
             validation_status = "validated",
@@ -1507,6 +1667,7 @@ function _add_qoblib_incumbent!(
     end
 
     qubo_value = QUBOTools.value(model, solution.state)
+    source_evaluation = _qoblib_source_evaluation(index, instance, solution.state)
     metadata = _qoblib_incumbent_metadata(root_path, group, info; source_value)
     _qoblib_tag_source_value_agreement!(
         metadata,
@@ -1526,6 +1687,8 @@ function _add_qoblib_incumbent!(
         sol;
         qubo_value,
         source_value = ismissing(source_value) ? missing : source_value,
+        source_objective = source_evaluation.source_objective,
+        source_feasible = source_evaluation.source_feasible,
         proven_optimal = info.proven_optimal,
         feasibility_status = "feasible",
         validation_status = "validated",
@@ -1608,6 +1771,7 @@ function build_qoblib!(
         for model_path in model_paths
             metadata = _qoblib_instance_metadata(root_path, group, model_path)
             model = QUBOTools.read_model(model_path, QOBLIBQS())
+            source = _qoblib_instance_source(root_path, group, model_path)
 
             merge!(QUBOTools.metadata(model), metadata)
             _validate_qoblib_metrics!(model, metrics, model_path)
@@ -1624,6 +1788,10 @@ function build_qoblib!(
                 source_commit     = metadata["source_commit"],
                 original_filename = metadata["original_filename"],
                 source_url        = metadata["source_url"],
+                source_format     = source.source_format,
+                source_text       = source.source_text,
+                source_encoding   = source.source_encoding,
+                source_metadata   = source.source_metadata,
                 metadata          = metadata,
             )
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -94,6 +94,8 @@ Reads the stored source formulation for an instance as a JuMP model.
 
 Currently, source formulations are loaded from instances that store an LP text
 blob under `/instances/{id}/source` with a `source_format = "lp"` attribute.
+The same source group may also carry provenance attributes such as upstream
+repository, commit, source path, URL, and content hash.
 """
 function source_model end
 
@@ -155,6 +157,8 @@ function remove_solver! end
     add_instance!(index::LibraryIndex, model::QUBOTools.Model{Int,Float64,Int}, collection = "standalone"; kwargs...)
 
 Adds a new instance and optional provenance metadata to the library index.
+Source formulations can be stored with `source_format`, `source_text`,
+`source_encoding`, and `source_metadata`.
 """
 function add_instance! end
 

--- a/src/library/instances.jl
+++ b/src/library/instances.jl
@@ -33,20 +33,68 @@ function _instance_source_encoding_value(source_encoding)
     end
 end
 
+function _instance_source_metadata_value(value)
+    if isnothing(value) || ismissing(value)
+        return nothing
+    elseif value isa AbstractString
+        return String(value)
+    elseif value isa Symbol
+        return String(value)
+    elseif value isa Number || value isa Bool
+        return value
+    else
+        return JSON.json(value)
+    end
+end
+
+function _write_instance_source_metadata!(source_group::HDF5.Group, source_metadata)
+    if isnothing(source_metadata)
+        return nothing
+    elseif !(source_metadata isa AbstractDict)
+        error("source_metadata must be a dictionary")
+    end
+
+    attrs = HDF5.attrs(source_group)
+
+    for (key, value) in pairs(source_metadata)
+        key = String(key)
+
+        if key == "source_format"
+            continue
+        end
+
+        attr_value = _instance_source_metadata_value(value)
+
+        if !isnothing(attr_value)
+            attrs[key] = attr_value
+        end
+    end
+
+    return nothing
+end
+
 function _write_instance_source!(
     group::HDF5.Group;
     source_format = nothing,
     source_text = nothing,
     source_encoding = nothing,
+    source_metadata = nothing,
 )
-    if isnothing(source_format) && isnothing(source_text) && isnothing(source_encoding)
+    if isnothing(source_format) &&
+       isnothing(source_text) &&
+       isnothing(source_encoding) &&
+       isnothing(source_metadata)
         return nothing
     elseif isnothing(source_format)
-        error("source_format is required when source_text or source_encoding is provided")
+        error(
+            "source_format is required when source_text, source_encoding, or " *
+            "source_metadata is provided",
+        )
     end
 
     source_group = HDF5.create_group(group, "source")
     HDF5.attrs(source_group)["source_format"] = String(source_format)
+    _write_instance_source_metadata!(source_group, source_metadata)
 
     if !isnothing(source_text)
         source_group["content"] = String(source_text)
@@ -76,6 +124,7 @@ function add_instance!(
     source_format = nothing,
     source_text = nothing,
     source_encoding = nothing,
+    source_metadata = nothing,
     metadata = nothing,
 )::Integer
     @assert isopen(index)
@@ -153,7 +202,13 @@ function add_instance!(
     group = HDF5.create_group(h5["instances"], string(i))
 
     QUBOTools.write_model(group, model, _qubin_format())
-    _write_instance_source!(group; source_format, source_text, source_encoding)
+    _write_instance_source!(
+        group;
+        source_format,
+        source_text,
+        source_encoding,
+        source_metadata,
+    )
 
     return i
 end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -71,6 +71,9 @@ function test_docs()
         @test occursin("No `.qs` or `.qs.xz` files", qoblib)
         @test occursin("Unavailable for canonical ingestion", qoblib)
         @test occursin("explicit naming and provenance", qoblib)
+        @test occursin("Source Formulation Storage", qoblib)
+        @test occursin("SHA-256 content hash", qoblib)
+        @test occursin("at most 1,000,000 bytes", qoblib)
     end
 
     return nothing

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -74,6 +74,8 @@ function test_docs()
         @test occursin("Source Formulation Storage", qoblib)
         @test occursin("SHA-256 content hash", qoblib)
         @test occursin("at most 1,000,000 bytes", qoblib)
+        @test occursin("`SolutionRecords.dual_bound`", qoblib)
+        @test occursin("`objective_bound` column", qoblib)
     end
 
     return nothing

--- a/test/library/access.jl
+++ b/test/library/access.jl
@@ -149,6 +149,13 @@ function test_library_access()
                     ),
                 ),
             )
+            source_metadata = Dict{String,Any}(
+                "source_repository" => "example/source",
+                "source_commit" => "abc123",
+                "source_path" => "models/source.lp",
+                "source_sha256" => "fixture-sha",
+                "source_size_bytes" => sizeof(source_text),
+            )
 
             QUBOLib.access(; path, clear = true) do index
                 instance = QUBOLib.add_instance!(
@@ -158,12 +165,19 @@ function test_library_access()
                     source_format = "lp",
                     source_text,
                     source_encoding,
+                    source_metadata,
                 )
 
                 source_group =
                     QUBOLib.archive(index)["instances"][string(instance)]["source"]
+                attrs = QUBOLib.HDF5.attrs(source_group)
 
-                @test QUBOLib.HDF5.attrs(source_group)["source_format"] == "lp"
+                @test attrs["source_format"] == "lp"
+                @test attrs["source_repository"] == "example/source"
+                @test attrs["source_commit"] == "abc123"
+                @test attrs["source_path"] == "models/source.lp"
+                @test attrs["source_sha256"] == "fixture-sha"
+                @test attrs["source_size_bytes"] == sizeof(source_text)
                 @test read(source_group["content"]) == source_text
                 @test QUBOLib.JSON.parse(read(source_group["encoding"])) ==
                       source_encoding


### PR DESCRIPTION
Summary

- Adds optional `source_metadata` persistence for HDF5 source groups so source provenance attributes live under `/instances/{id}/source`.
- Adds forward-compatible QOBLIB ingestion for canonical QS/QUBO artifacts when a group declares authoritative LP source metadata: it stores LP provenance and bounded source text, and populates `source_objective`, `dual_bound`, and `source_feasible` when source evaluation is possible. Current shipped QOBLIB groups do not declare source model paths, so this path is covered by fixtures and future source-aware groups.
- Documents the QOBLIB source-text storage policy, clarifies `dual_bound` as the canonical imported bound with `objective_bound` retained for compatibility, and updates source-schema release notes.

Tests

- `julia --project -e 'import Pkg; Pkg.test()'` passed, 149 tests.
- `make test-build` passed, 176 tests.
- `julia --project=docs ./docs/make.jl --skip-deploy` passed.
- `git diff --check` passed.

Branch Hygiene

- Base branch: `main`.
- Source branch: `fix/issue-46-source-formulations`.
- Source branch point: current `origin/main` at `ef0f24b`.
- Stacked status: not stacked.
- Prerequisite PRs: none. The previous PR from this branch, #48, is already merged into `main`; this PR contains one new commit on top of current `main`.

Refs #46
