### PR TITLE
Fix release follow-up automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,13 +83,15 @@ jobs:
         git push origin --delete "refs/tags/mirror-data" || true
 
     - name: Switch to mirror branch
-      run: git checkout origin mirror
+      run: |
+        git fetch --no-tags --depth=1 origin mirror:refs/remotes/origin/mirror
+        git checkout --detach origin/mirror
 
     - name: Publish mirror release
       run: >
         gh release create "mirror-data"
         --prerelease
         --notes-file "$GITHUB_WORKSPACE/dist/build/mirror/NOTES.md"
-        --title "$SUBJECT"
+        --title "QUBOLib Data Mirror"
         --target $GITHUB_SHA
         $GITHUB_WORKSPACE/dist/build/mirror/*.zip


### PR DESCRIPTION
## Summary

- fetch and detach the `mirror` branch correctly before publishing `mirror-data`
- use an explicit mirror release title instead of the unset `$SUBJECT`

## Operational follow-ups completed outside this PR

- republished `mirror-data` with the v0.2.0 mirror assets
- added a write-enabled TagBot deploy key and replaced the `SSH_KEY` Actions secret
- verified the TagBot key with an SSH dry-run push

## Verification

- `git diff --check`
- verified `mirror-data` release asset list with `gh release view`
