### PR TITLE
ci: harden TagBot permissions

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,6 +6,11 @@ on:
       - created
   workflow_dispatch:
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Summary

- Add explicit TagBot workflow permissions for tag/release writes, manual-intervention issues, and PR changelog reads.
- Keep the existing SSH deploy-key configuration because this repository has tag-triggered release/docs workflows.

Context

- Recent TagBot run 27790321789 failed while trying to push v0.2.0 over SSH.
- This change makes the GITHUB_TOKEN permission contract explicit and preserves the deploy-key path.

Validation

- git diff --check

Notes

- This PR does not change package code or release metadata.
