### PR TITLE
[codex] Add release process guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.2.0 - 2026-06-18
+
+### Breaking changes
+
+- No intentional API-breaking changes are documented. This is a pre-1.0 minor
+  release because QOBLIB provenance, source-model metadata, and solution-record
+  schema behavior changed.
+
+### Added / Changed / Maintenance
+
+- Added QOBLIB source-model provenance and source-objective evaluation support.
+- Added nullable `source_objective`, `dual_bound`, and `source_feasible`
+  fields to solution records, with migration support for existing artifacts.
+- Updated QOBLIB documentation for canonical QS/QUBO ingestion and LP-only
+  source-class provenance.
+
 ## v0.1.3 - 2026-06-03
 
 - Added package and data release maintenance documentation.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,20 +8,46 @@ This repository has two release streams:
 ## Package Release
 
 1. Open a release PR that bumps `version` in `Project.toml`.
-2. Run the package tests and documentation build.
-3. Merge the release PR after CI is green.
-4. Trigger Registrator on the merge commit, including release notes:
+2. Add a `CHANGELOG.md` section for `vX.Y.Z`.
+3. Update `docs/Project.toml` self-compat for `QUBOLib` so it includes the
+   target release line.
+   - For `0.Y.Z`, include `0.Y`.
+   - For `0.0.Z`, include `0.0.Z`.
+   - For `X.Y.Z` with `X > 0`, include `X`.
+4. Run the static package-release preflight:
 
-   ```markdown
-   @JuliaRegistrator register
-
-   Release notes:
-
-   - ...
+   ```bash
+   julia --project=. scripts/release_check.jl
    ```
 
-5. Confirm the General registry PR merges.
-6. Let TagBot create the package tag and GitHub release. If the package tag was
+5. Run the package tests and documentation build:
+
+   ```bash
+   julia --project=. -e 'import Pkg; Pkg.test()'
+   julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'
+   julia --project=docs docs/make.jl --skip-deploy
+   ```
+
+6. Merge the release PR after CI is green.
+7. Trigger Registrator on the merge commit using `release-notes-template.md`:
+
+   ```bash
+   gh api repos/JuliaQUBO/QUBOLib.jl/commits/<merge-sha>/comments -f body="$(cat release-notes-template.md)"
+   ```
+
+   The release notes for a pre-1.0 minor release should include a
+   `Breaking changes` or `Changelog` section. General may label pre-1.0 minor
+   releases as `BREAKING`, and AutoMerge requires one of those words in the
+   release notes when that label is present.
+
+8. Confirm the General registry PR merges:
+
+   ```bash
+   gh pr checks <general-pr-number> --repo JuliaRegistries/General --watch
+   gh pr view <general-pr-number> --repo JuliaRegistries/General --json state,mergedAt,mergeCommit,url
+   ```
+
+9. Let TagBot create the package tag and GitHub release. If the package tag was
    created manually before TagBot ran, create the GitHub release manually too:
 
    ```bash
@@ -34,6 +60,14 @@ This repository has two release streams:
    git ls-remote --tags origin refs/tags/vX.Y.Z 'refs/tags/vX.Y.Z^{}'
    gh release view vX.Y.Z --repo JuliaQUBO/QUBOLib.jl
    ```
+
+10. Verify `Pkg.add` from a fresh depot and project:
+
+    ```bash
+    tmp="$(mktemp -d)"
+    mkdir -p "$tmp/depot" "$tmp/proj"
+    JULIA_DEPOT_PATH="$tmp/depot" julia --startup-file=no --project="$tmp/proj" -e 'using Pkg; Pkg.add("QUBOLib"); deps = Pkg.dependencies(); versions = [(pkg.name, pkg.version) for pkg in values(deps) if pkg.name == "QUBOLib"]; @show versions'
+    ```
 
 ## TagBot Setup
 

--- a/release-notes-template.md
+++ b/release-notes-template.md
@@ -1,0 +1,19 @@
+@JuliaRegistrator register
+
+Release notes:
+
+## Breaking changes
+
+- No breaking changes, or list the behavioral/API change that makes this release breaking.
+
+## Added
+
+- TODO
+
+## Fixed
+
+- TODO
+
+## Maintenance
+
+- TODO

--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -1,0 +1,158 @@
+#!/usr/bin/env julia
+
+using Pkg
+using TOML
+
+const ROOT = normpath(joinpath(@__DIR__, ".."))
+
+function release_line_compat(version::VersionNumber)
+    if version.major == 0
+        return version.minor == 0 ? "0.0.$(version.patch)" : "0.$(version.minor)"
+    end
+
+    return string(version.major)
+end
+
+function check!(failures::Vector{String}, condition::Bool, message::String)
+    condition || push!(failures, message)
+    return nothing
+end
+
+function project_file(parts...)
+    return joinpath(ROOT, parts...)
+end
+
+function read_toml(parts...)
+    return TOML.parsefile(project_file(parts...))
+end
+
+function compat_entries(compat::AbstractString)
+    return strip.(split(compat, ","))
+end
+
+function compat_allows(compat::AbstractString, version::VersionNumber)
+    return version in Pkg.Types.semver_spec(compat)
+end
+
+function release_heading_matches(line::AbstractString, version::VersionNumber)
+    prefix = "## v$(version)"
+    startswith(line, prefix) || return false
+    length(line) == length(prefix) && return true
+    return line[length(prefix) + 1] in (' ', '-', '(')
+end
+
+function release_section(changelog::String, version::VersionNumber)
+    lines = split(changelog, '\n')
+    start = findfirst(line -> release_heading_matches(line, version), lines)
+    start === nothing && return nothing
+
+    next_heading = findnext(line -> startswith(line, "## "), lines, start + 1)
+    stop = next_heading === nothing ? lastindex(lines) : next_heading - 1
+    return join(lines[start:stop], "\n")
+end
+
+function main()
+    failures = String[]
+    warnings = String[]
+
+    project = read_toml("Project.toml")
+    docs_project = read_toml("docs", "Project.toml")
+    test_project = read_toml("test", "Project.toml")
+
+    version = VersionNumber(project["version"])
+    expected_self_compat = release_line_compat(version)
+
+    check!(failures, project["name"] == "QUBOLib", "Project.toml name is not QUBOLib.")
+
+    root_deps = project["deps"]
+    docs_deps = docs_project["deps"]
+    test_deps = test_project["deps"]
+    root_compat = project["compat"]
+    docs_compat = docs_project["compat"]
+    docs_self_compat = get(docs_compat, "QUBOLib", nothing)
+
+    check!(
+        failures,
+        get(docs_deps, "QUBOLib", nothing) == project["uuid"],
+        "docs/Project.toml must depend on this package UUID for QUBOLib.",
+    )
+    check!(
+        failures,
+        docs_self_compat !== nothing,
+        "docs/Project.toml must declare QUBOLib compat.",
+    )
+
+    if docs_self_compat !== nothing
+        check!(
+            failures,
+            expected_self_compat in compat_entries(docs_self_compat),
+            "docs/Project.toml compat for QUBOLib must include \"$expected_self_compat\" for version $version.",
+        )
+        check!(
+            failures,
+            compat_allows(docs_self_compat, version),
+            "docs/Project.toml compat for QUBOLib must allow version $version.",
+        )
+    end
+
+    check!(
+        failures,
+        get(docs_compat, "QUBOTools", nothing) == root_compat["QUBOTools"],
+        "docs/Project.toml QUBOTools compat must match Project.toml.",
+    )
+    check!(
+        failures,
+        get(docs_compat, "SQLite", nothing) == root_compat["SQLite"],
+        "docs/Project.toml SQLite compat must match Project.toml.",
+    )
+    check!(
+        failures,
+        get(docs_deps, "QUBOTools", nothing) == root_deps["QUBOTools"],
+        "docs/Project.toml QUBOTools UUID must match Project.toml.",
+    )
+    check!(
+        failures,
+        get(test_deps, "QUBOTools", nothing) == root_deps["QUBOTools"],
+        "test/Project.toml QUBOTools UUID must match Project.toml.",
+    )
+    check!(
+        failures,
+        haskey(root_compat, "julia"),
+        "Project.toml must declare Julia compat.",
+    )
+
+    changelog = read(project_file("CHANGELOG.md"), String)
+    section = release_section(changelog, version)
+    check!(
+        failures,
+        section !== nothing,
+        "CHANGELOG.md must contain a release heading for v$version.",
+    )
+
+    if section !== nothing &&
+       version.major == 0 &&
+       iszero(version.patch) &&
+       !occursin(r"(?i)\b(breaking|changelog)\b", section)
+        push!(
+            warnings,
+            "CHANGELOG.md section for v$version does not mention `breaking` or `changelog`; General AutoMerge may require one of those words if the registry labels the release BREAKING.",
+        )
+    end
+
+    if isempty(failures)
+        println("Release preflight passed for QUBOLib v$version.")
+        println("Expected docs self-compat entry: QUBOLib = \"$expected_self_compat\".")
+    else
+        println(stderr, "Release preflight failed:")
+        foreach(message -> println(stderr, "- ", message), failures)
+    end
+
+    if !isempty(warnings)
+        println(stderr, "\nWarnings:")
+        foreach(message -> println(stderr, "- ", message), warnings)
+    end
+
+    return isempty(failures) ? 0 : 1
+end
+
+exit(main())


### PR DESCRIPTION
## Summary

Adds QUBOLib release guardrails as part of JuliaQUBO/QUBO.jl#44:

- add `scripts/release_check.jl` to validate package-release metadata before Registrator;
- update the existing `RELEASE.md` package-release checklist while leaving the data-artifact release flow intact;
- add `release-notes-template.md` with explicit `Breaking changes` wording for pre-1.0 minor releases that General labels as breaking;
- add the missing `CHANGELOG.md` entry for the already-released `v0.2.0`, so the new preflight passes on the current package version.

The preflight checks QUBOLib docs self-compat, selected docs/test dependency consistency, Julia compat presence, and the current changelog section.

## Validation

- `julia +release --project=. scripts/release_check.jl`
- `julia +release --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
- `julia +release --project=docs docs/make.jl --skip-deploy`
- `julia +release --project=. -e 'import Pkg; Pkg.test()'`
- `git diff --cached --check`

The package test passed `149/149`. The docs build passed with the expected local deployment-skip warning.
