### PR TITLE
Release QUBOLib v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.2.1 - 2026-06-22
+
+### Fixed
+
+- Fixed mirror data release publishing.
+
+### Maintenance
+
+- Hardened TagBot workflow permissions for package release automation.
+- Added release process guardrails, including a static package-release
+  preflight script and Registrator release-note template.
+
 ## v0.2.0 - 2026-06-18
 
 ### Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBOLib"
 uuid = "c2d3eca2-2309-4628-88a9-9d4a554e7c47"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"


### PR DESCRIPTION
## Summary
- Bump QUBOLib to v0.2.1.
- Add changelog notes for the mirror data publishing fix and release automation guardrails.

## Validation
- `julia --project=. scripts/release_check.jl`
- `julia --project=. -e 'import Pkg; Pkg.test()'`
- `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
- `julia --project=docs docs/make.jl --skip-deploy`