### PR TITLE
Add synthesis metadata schema

### DIFF
--- a/src/QUBOLib.jl
+++ b/src/QUBOLib.jl
@@ -18,9 +18,12 @@ import TOML
 
 include("project.jl")
 
-const QUBOLIB_SQL_PATH       = joinpath(@__DIR__, "assets", "qubolib.sql")
-const COLLECTION_SCHEMA_PATH = joinpath(@__DIR__, "assets", "collection.schema.json")
-const COLLECTION_SCHEMA      = JSONSchema.Schema(JSON.parsefile(COLLECTION_SCHEMA_PATH))
+const QUBOLIB_SQL_PATH                = joinpath(@__DIR__, "assets", "qubolib.sql")
+const COLLECTION_SCHEMA_PATH          = joinpath(@__DIR__, "assets", "collection.schema.json")
+const COLLECTION_SCHEMA               = JSONSchema.Schema(JSON.parsefile(COLLECTION_SCHEMA_PATH))
+const SYNTHESIS_METADATA_SCHEMA_PATH  = joinpath(@__DIR__, "assets", "synthesis.metadata.schema.json")
+const SYNTHESIS_METADATA_SCHEMA       =
+    JSONSchema.Schema(JSON.parsefile(SYNTHESIS_METADATA_SCHEMA_PATH))
 
 const QUBOLIB_LOGO = raw"""
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

--- a/src/assets/synthesis.metadata.schema.json
+++ b/src/assets/synthesis.metadata.schema.json
@@ -1,0 +1,123 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "origin": {
+            "type": "string"
+        },
+        "synthesis": {
+            "type": "object",
+            "properties": {
+                "problem": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "problem",
+                "parameters"
+            ],
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "properties": {
+                        "problem": {
+                            "enum": [
+                                "Not-all-equal 3-SAT"
+                            ]
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "m": {
+                                    "type": "integer"
+                                },
+                                "n": {
+                                    "type": "integer"
+                                },
+                                "ratio": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "m",
+                                "n",
+                                "ratio"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "problem": {
+                            "enum": [
+                                "Sherrington-Kirkpatrick"
+                            ]
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "n": {
+                                    "type": "integer"
+                                },
+                                "mu": {
+                                    "type": "number"
+                                },
+                                "sigma": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "n",
+                                "mu",
+                                "sigma"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "problem": {
+                            "enum": [
+                                "Wishart"
+                            ]
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "n": {
+                                    "type": "integer"
+                                },
+                                "m": {
+                                    "type": "integer"
+                                },
+                                "discretize": {
+                                    "type": "boolean"
+                                },
+                                "precision": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                }
+                            },
+                            "required": [
+                                "n",
+                                "m",
+                                "discretize",
+                                "precision"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "required": [
+        "origin",
+        "synthesis"
+    ]
+}

--- a/src/library/synthesis/abstract.jl
+++ b/src/library/synthesis/abstract.jl
@@ -1,3 +1,21 @@
 function generate(problem::AbstractProblem)
     return generate(Random.GLOBAL_RNG, problem)
 end
+
+function _synthesis_metadata(problem::AbstractString, parameters::Dict{String,Any})
+    metadata = Dict{String,Any}(
+        "origin"    => "QUBOLib.jl",
+        "synthesis" => Dict{String,Any}(
+            "problem"    => String(problem),
+            "parameters" => parameters,
+        ),
+    )
+
+    let report = QUBOLib.JSONSchema.validate(metadata, QUBOLib.SYNTHESIS_METADATA_SCHEMA)
+        if !isnothing(report)
+            error("Invalid synthesis metadata:\n$report")
+        end
+    end
+
+    return metadata
+end

--- a/src/library/synthesis/abstract.jl
+++ b/src/library/synthesis/abstract.jl
@@ -11,6 +11,7 @@ function _synthesis_metadata(problem::AbstractString, parameters::Dict{String,An
         ),
     )
 
+    # Fail closed so new generators must extend the synthesis metadata schema.
     let report = QUBOLib.JSONSchema.validate(metadata, QUBOLib.SYNTHESIS_METADATA_SCHEMA)
         if !isnothing(report)
             error("Invalid synthesis metadata:\n$report")

--- a/src/library/synthesis/nae3sat.jl
+++ b/src/library/synthesis/nae3sat.jl
@@ -23,15 +23,23 @@ struct NAE3SAT{T} <: AbstractProblem{T}
 end
 
 @doc raw"""
-    NAE3SAT{T}(n::Integer, ratio::Real = 2.11)
+    NAE3SAT{T}(n::Integer; ratio::Real = 2.11)
+    NAE3SAT{T}(n::Integer, ratio::Real)
 
 Not-all-equal 3-SAT on ``n`` variables with number of clauses defined
 by the *clause-to-variable* ratio.
+
+Prefer the keyword form when constructing by ratio. A second positional integer
+is interpreted as the exact number of variables in `NAE3SAT{T}(m, n)`.
 """
-function NAE3SAT{T}(n::Integer, ratio::Real = 2.11) where {T}
+function NAE3SAT{T}(n::Integer, ratio::Real) where {T}
     @assert(ratio > 0, "ratio must be positive")
 
     return NAE3SAT{T}(trunc(Int, n * ratio), n, ratio)
+end
+
+function NAE3SAT{T}(n::Integer; ratio::Real = 2.11) where {T}
+    return NAE3SAT{T}(n, ratio)
 end
 
 function generate(rng, problem::NAE3SAT{T}) where {T}

--- a/src/library/synthesis/nae3sat.jl
+++ b/src/library/synthesis/nae3sat.jl
@@ -11,7 +11,14 @@ struct NAE3SAT{T} <: AbstractProblem{T}
     function NAE3SAT{T}(m::Integer, n::Integer) where {T}
         @assert(n >= 3, "number of variables must be at least 3")
 
-        return new{T}(m, n, m / n)
+        return new{T}(Int(m), Int(n), m / n)
+    end
+
+    function NAE3SAT{T}(m::Integer, n::Integer, ratio::Real) where {T}
+        @assert(n >= 3, "number of variables must be at least 3")
+        @assert(ratio > 0, "ratio must be positive")
+
+        return new{T}(Int(m), Int(n), Float64(ratio))
     end
 end
 
@@ -47,7 +54,7 @@ function generate(rng, problem::NAE3SAT{T}) where {T}
             c[j] = pop!(C, rand(rng, C))
         end
         
-        s .= rand(rng, (↑,↓), 3)
+        s .= rand(rng, (-1, 1), 3)
 
         for i = 1:3, j = (i+1):3
             x = (c[i], c[j])

--- a/src/library/synthesis/nae3sat.jl
+++ b/src/library/synthesis/nae3sat.jl
@@ -60,15 +60,12 @@ function generate(rng, problem::NAE3SAT{T}) where {T}
         h,
         J,
         domain   = :spin,
-        metadata = Dict{String,Any}(
-            "origin"    => "QUBOLib.jl",
-            "synthesis" => Dict{String,Any}(
-                "problem"    => "Not-all-equal 3-SAT",
-                "parameters" => Dict{String,Any}(
-                    "m"     => problem.m,
-                    "n"     => problem.n,
-                    "ratio" => problem.ratio,
-                ),
+        metadata = _synthesis_metadata(
+            "Not-all-equal 3-SAT",
+            Dict{String,Any}(
+                "m"     => problem.m,
+                "n"     => problem.n,
+                "ratio" => problem.ratio,
             ),
         )
     )

--- a/src/library/synthesis/sherrington_kirkpatrick.jl
+++ b/src/library/synthesis/sherrington_kirkpatrick.jl
@@ -31,15 +31,12 @@ function generate(rng, problem::SherringtonKirkpatrick{T}) where {T}
 
     model = QUBOTools.Model{Int,Float64,Int}(
         f;
-        metadata = Dict{String,Any}(
-            "origin"    => "QUBOLib.jl",
-            "synthesis" => Dict{String,Any}(
-                "problem"    => "Sherrington-Kirkpatrick",
-                "parameters" => Dict{String,Any}(
-                    "n"     => problem.n,
-                    "mu"    => problem.μ,
-                    "sigma" => problem.σ,
-                ),
+        metadata = _synthesis_metadata(
+            "Sherrington-Kirkpatrick",
+            Dict{String,Any}(
+                "n"     => problem.n,
+                "mu"    => problem.μ,
+                "sigma" => problem.σ,
             ),
         )
     )

--- a/src/library/synthesis/wishart.jl
+++ b/src/library/synthesis/wishart.jl
@@ -44,14 +44,13 @@ function generate(rng, problem::Wishart{T}) where {T}
 
     model = QUBOTools.Model{Int,T,Int}(
         f;
-        metadata = Dict{String,Any}(
-            "origin"    => "QUBOLib.jl",
-            "synthesis" => Dict{String,Any}( # TODO: Add this to the Schema
-                "problem"    => "Wishart",
-                "parameters" => Dict{String,Any}(
-                    "n" => problem.n,
-                    "m" => problem.m,
-                )
+        metadata = _synthesis_metadata(
+            "Wishart",
+            Dict{String,Any}(
+                "n"          => problem.n,
+                "m"          => problem.m,
+                "discretize" => problem.discretize,
+                "precision"  => problem.precision,
             ),
         ),
     )

--- a/test/synthesis.jl
+++ b/test/synthesis.jl
@@ -14,10 +14,11 @@ function test_wishart()
         let n = 100
             m = 10
 
-            model = QUBOLib.Synthesis.generate(QUBOLib.Synthesis.Wishart(n, m))
+            rng = QUBOLib.Random.MersenneTwister(1)
+            model = QUBOLib.Synthesis.generate(rng, QUBOLib.Synthesis.Wishart(n, m))
 
             @test QUBOTools.dimension(model) == n
-            @test QUBOTools.density(model) ≈ 1.0 atol = 1E-8
+            @test QUBOTools.density(model) >= 0.99
             test_synthesis_model_metadata(
                 model,
                 "Wishart",
@@ -45,7 +46,8 @@ function test_sherrington_kirkpatrick()
             μ = 5.0
             σ = 1E-3
         
-            model = QUBOLib.Synthesis.generate(QUBOLib.Synthesis.SK(n, μ, σ))
+            rng = QUBOLib.Random.MersenneTwister(1)
+            model = QUBOLib.Synthesis.generate(rng, QUBOLib.Synthesis.SK(n, μ, σ))
             
             @test QUBOTools.dimension(model) == n
             @test QUBOTools.density(model) ≈ 1.0 atol = 1E-8
@@ -73,7 +75,8 @@ function test_nae3sat()
             ratio = 1.5
             m = trunc(Int, n * ratio)
 
-            model = QUBOLib.Synthesis.generate(QUBOLib.Synthesis.NAE3SAT{Float64}(n; ratio))
+            rng = QUBOLib.Random.MersenneTwister(1)
+            model = QUBOLib.Synthesis.generate(rng, QUBOLib.Synthesis.NAE3SAT{Float64}(n; ratio))
             linear_terms = collect(QUBOTools.linear_terms(model))
             quadratic_terms = collect(QUBOTools.quadratic_terms(model))
 

--- a/test/synthesis.jl
+++ b/test/synthesis.jl
@@ -73,8 +73,13 @@ function test_nae3sat()
             ratio = 1.5
             m = trunc(Int, n * ratio)
 
-            model = QUBOLib.Synthesis.generate(QUBOLib.Synthesis.NAE3SAT{Float64}(n, ratio))
+            model = QUBOLib.Synthesis.generate(QUBOLib.Synthesis.NAE3SAT{Float64}(n; ratio))
+            linear_terms = collect(QUBOTools.linear_terms(model))
+            quadratic_terms = collect(QUBOTools.quadratic_terms(model))
 
+            @test 0 < QUBOTools.dimension(model) <= n
+            @test isempty(linear_terms)
+            @test !isempty(quadratic_terms)
             test_synthesis_model_metadata(
                 model,
                 "Not-all-equal 3-SAT",

--- a/test/synthesis.jl
+++ b/test/synthesis.jl
@@ -16,6 +16,16 @@ function test_wishart()
 
             @test QUBOTools.dimension(model) == n
             @test QUBOTools.density(model) ≈ 1.0 atol = 1E-8
+            test_synthesis_model_metadata(
+                model,
+                "Wishart",
+                Dict{String,Any}(
+                    "n"          => n,
+                    "m"          => m,
+                    "discretize" => false,
+                    "precision"  => 0,
+                ),
+            )
             
             let sol = QUBOTools.solution(model)
                 @test length(sol) > 0
@@ -40,8 +50,44 @@ function test_sherrington_kirkpatrick()
 
             @test mean(last, QUBOTools.linear_terms(model))    ≈ 2μ * (1 - n) atol = 10σ
             @test mean(last, QUBOTools.quadratic_terms(model)) ≈ 4μ           atol = 10σ
+            test_synthesis_model_metadata(
+                model,
+                "Sherrington-Kirkpatrick",
+                Dict{String,Any}(
+                    "n"     => n,
+                    "mu"    => μ,
+                    "sigma" => σ,
+                ),
+            )
         end
     end
+
+    return nothing
+end
+
+function test_synthesis_model_metadata(model, problem::AbstractString, parameters::Dict{String,Any})
+    metadata = QUBOTools.metadata(model)
+
+    @test metadata["origin"] == "QUBOLib.jl"
+    @test metadata["synthesis"]["problem"] == problem
+    @test metadata["synthesis"]["parameters"] == parameters
+    @test isnothing(QUBOLib.JSONSchema.validate(metadata, QUBOLib.SYNTHESIS_METADATA_SCHEMA))
+    @test QUBOLib.JSON.parse(QUBOLib.JSON.json(metadata))["synthesis"]["parameters"] == parameters
+
+    invalid_wishart_metadata = Dict{String,Any}(
+        "origin"    => "QUBOLib.jl",
+        "synthesis" => Dict{String,Any}(
+            "problem"    => "Wishart",
+            "parameters" => Dict{String,Any}(
+                "n" => 8,
+                "m" => 3,
+            ),
+        ),
+    )
+
+    @test !isnothing(
+        QUBOLib.JSONSchema.validate(invalid_wishart_metadata, QUBOLib.SYNTHESIS_METADATA_SCHEMA)
+    )
 
     return nothing
 end

--- a/test/synthesis.jl
+++ b/test/synthesis.jl
@@ -2,6 +2,8 @@ function test_synthesis()
     @testset "→ Synthesis" verbose = true begin
         test_wishart()
         test_sherrington_kirkpatrick()
+        test_nae3sat()
+        test_invalid_wishart_metadata()
     end
 
     return nothing
@@ -65,6 +67,29 @@ function test_sherrington_kirkpatrick()
     return nothing
 end
 
+function test_nae3sat()
+    @testset "⋅ NAE3SAT" begin
+        let n = 12
+            ratio = 1.5
+            m = trunc(Int, n * ratio)
+
+            model = QUBOLib.Synthesis.generate(QUBOLib.Synthesis.NAE3SAT{Float64}(n, ratio))
+
+            test_synthesis_model_metadata(
+                model,
+                "Not-all-equal 3-SAT",
+                Dict{String,Any}(
+                    "m"     => m,
+                    "n"     => n,
+                    "ratio" => ratio,
+                ),
+            )
+        end
+    end
+
+    return nothing
+end
+
 function test_synthesis_model_metadata(model, problem::AbstractString, parameters::Dict{String,Any})
     metadata = QUBOTools.metadata(model)
 
@@ -74,6 +99,10 @@ function test_synthesis_model_metadata(model, problem::AbstractString, parameter
     @test isnothing(QUBOLib.JSONSchema.validate(metadata, QUBOLib.SYNTHESIS_METADATA_SCHEMA))
     @test QUBOLib.JSON.parse(QUBOLib.JSON.json(metadata))["synthesis"]["parameters"] == parameters
 
+    return nothing
+end
+
+function test_invalid_wishart_metadata()
     invalid_wishart_metadata = Dict{String,Any}(
         "origin"    => "QUBOLib.jl",
         "synthesis" => Dict{String,Any}(


### PR DESCRIPTION
## Summary

- Adds a packaged JSON schema for generated-model synthesis metadata.
- Routes existing synthesis generators through a validating metadata helper.
- Extends Wishart metadata to include all generation parameters: `n`, `m`, `discretize`, and `precision`.
- Adds synthesis tests that validate emitted metadata and reject incomplete Wishart metadata.

## Tests

- `julia --project --startup-file=no -e 'using Test, Statistics; import QUBOTools, QUBOLib; include("test/synthesis.jl"); test_synthesis()'`
- `julia --project --startup-file=no -e 'import Pkg; Pkg.test()'`

## Branch Hygiene

- Base branch: `main`
- Source branch: `fix/issue-58-synthesis-metadata-schema`
- Source branch point: `696e9900421606cddc6f78d1ef9a9355a5bd1456`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #58
