### PR TITLE
Standardize CI and Dependabot baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,24 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "julia"
+    directory: "/scripts/build"
+    schedule:
+      interval: "weekly"
+    groups:
+      build-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/test"
+    schedule:
+      interval: "weekly"
+    groups:
+      test-julia-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,7 @@ jobs:
     - uses: julia-actions/setup-julia@v3
       with:
         version: '1.10'
-    # - uses: actions/cache@v2.1.7
-    #   with:
-    #     path: ~/.julia/   # A list of files, directories, and wildcard patterns to cache and restore
-    #     key: ${{ runner.os }}-${{ hashFiles('**/Project.toml') }}
+    - uses: julia-actions/cache@v3
 
     - name: Create distribution directories
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
         uses: julia-actions/setup-julia@v3
         with:
           version: '1'
+      - uses: julia-actions/cache@v3
       - name: Develop QUBOLib.jl
         run: julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd())'
       - name: Build Package
@@ -41,6 +42,7 @@ jobs:
         uses: julia-actions/setup-julia@v3
         with:
           version: '1'
+      - uses: julia-actions/cache@v3
       - name: Develop QUBOLib.jl
         run: julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd())'
       - name: Build Package


### PR DESCRIPTION
## Summary

- add `julia-actions/cache@v3` to the documentation and data deployment Julia jobs
- add weekly Dependabot coverage for the checked-in `/scripts/build` and `/test` Julia projects
- keep the existing package `CI` matrix unchanged: Julia `1.10` and `1` on Ubuntu, plus Julia `1` and `1.10` on Windows

Closes #64.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "parsed #{path}" }' .github/dependabot.yml .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/deploy.yml .github/workflows/TagBot.yml .github/workflows/docs-cleanup.yml`
- `ruby -e 'require "yaml"; projects = Dir.glob("**/Project.toml", File::FNM_DOTMATCH).map { |p| "/" + File.dirname(p).sub(/^\.$/, "") }.sort; cfg = YAML.load_file(".github/dependabot.yml"); dirs = cfg.fetch("updates").select { |u| u["package-ecosystem"] == "julia" }.map { |u| u["directory"] }.sort; puts "projects=#{projects.join(",")}"; puts "dependabot=#{dirs.join(",")}"; missing = projects - dirs; abort("missing dependabot dirs: #{missing.join(",")}") unless missing.empty?'`
- `git diff --check`
- `actionlint`
- `julia +1.12 --project -e 'import Pkg; Pkg.test()'`

Local note: `julia --project -e 'import Pkg; Pkg.test()'` with local Julia 1.10.11 failed before test execution because the ignored local `Manifest.toml` is stamped with Julia 1.12.0 and Pkg could not locate `OpenSSL_jll`. The latest upstream `main` CI run for `47cb766` is green, and PR CI should exercise the required Julia 1.10 matrix.

## Remaining Drift / Exceptions

- Documentation and deployment workflows remain repo-specific and are not promoted as branch-protection gates in this wave.
- The deployment workflow keeps its existing trigger and release behavior; this PR only normalizes Julia caching there.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `47cb766`
- Head branch: `fix/issue-64-ci-dependabot-baseline`
- Stacked status: not stacked; no prerequisite PRs
