### PR TITLE
Correct release checklist step numbering

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,14 +54,14 @@ This repository has two release streams:
    gh release create vX.Y.Z --title "QUBOLib vX.Y.Z" --notes-file /path/to/notes.md --target <merge-commit>
    ```
 
-7. Verify that `vX.Y.Z` points at the registered merge commit:
+10. Verify that `vX.Y.Z` points at the registered merge commit:
 
    ```bash
    git ls-remote --tags origin refs/tags/vX.Y.Z 'refs/tags/vX.Y.Z^{}'
    gh release view vX.Y.Z --repo JuliaQUBO/QUBOLib.jl
    ```
 
-10. Verify `Pkg.add` from a fresh depot and project:
+11. Verify `Pkg.add` from a fresh depot and project:
 
     ```bash
     tmp="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- renumber the final package-release checklist steps from `7`, `10` to
  `10`, `11`
- leave the release procedure unchanged

## Acceptance criteria

- [x] The package-release checklist is numbered sequentially from 1 through 11.
- [x] Only documentation changes.

## Checks

- `git diff --check` — passed
- inspected every top-level numbered item in the Package Release section

## Branch Hygiene

- Base branch: `main`
- Source branch point: `e8996d60b41b5b8fa7cbeb2f8df0ebe9ceebd916`
- Stacked: no
- Prerequisite PRs: none

Closes #68.
